### PR TITLE
feat: add coroutine-safe LogContext propagation, samples, build refactor, and CI support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: Run tests
+    name: Run all tests
     runs-on: macos-latest
     steps:
       - name: Check out code
@@ -27,7 +27,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Run all tests
-        run: ./gradlew allTests --continue -x jsBrowserTest -x wasmJsBrowserTest -x kotlinWasmStoreYarnLock
+        run: ./gradlew :logger:allTests :logger-coroutines:allTests --continue -x jsBrowserTest -x wasmJsBrowserTest -x kotlinWasmStoreYarnLock
 
   publish:
     name: Release build and publish
@@ -48,17 +48,21 @@ jobs:
 
       - name: Validate version matches release tag
         run: |
-          VERSION=$(grep '^version = ' logger/build.gradle.kts | sed 's/version = "//;s/"//')
+          VERSION=$(grep '^kmplogger.version=' gradle.properties | cut -d'=' -f2)
           TAG="${{ github.event.release.tag_name }}"
           TAG="${TAG#v}"
           if [ "$VERSION" != "$TAG" ]; then
-            echo "Version mismatch: build.gradle.kts has '$VERSION' but release tag is '$TAG'"
+            echo "Version mismatch: gradle.properties has '$VERSION' but release tag is '$TAG'"
             exit 1
           fi
           echo "Version check passed: $VERSION"
 
-      - name: Publish to MavenCentral
-        run: ./gradlew publishToMavenCentral --no-configuration-cache
+      - name: Publish to Maven Central
+        run: >
+          ./gradlew
+          :logger:publishAndReleaseToMavenCentral
+          :logger-coroutines:publishAndReleaseToMavenCentral
+          --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.idea/runConfigurations/All_Tests_All_Platforms.xml
+++ b/.idea/runConfigurations/All_Tests_All_Platforms.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="All Tests - All Platforms" type="GradleRunConfiguration" factoryName="Gradle">
-    <ExternalSystemSettings>
-      <option name="executionName" />
-      <option name="externalProjectPath" value="$PROJECT_DIR$" />
-      <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="--continue" />
-      <option name="taskDescriptions">
-        <list />
-      </option>
-      <option name="taskNames">
-        <list>
-          <option value=":logger:allTests" />
-        </list>
-      </option>
-      <option name="vmOptions" />
-    </ExternalSystemSettings>
-    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
-    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-    <DebugAllEnabled>false</DebugAllEnabled>
-    <ForceTestExec>true</ForceTestExec>
-    <method v="2" />
-  </configuration>
+    <configuration name="All Tests - All Platforms" default="false" factoryName="Gradle"
+        type="GradleRunConfiguration">
+        <ExternalSystemSettings>
+            <option name="executionName" />
+            <option name="externalProjectPath" value="$PROJECT_DIR$" />
+            <option name="externalSystemIdString" value="GRADLE" />
+            <option name="scriptParameters" value="--continue" />
+            <option name="taskDescriptions">
+                <list />
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value=":logger:allTests" />
+                    <option value=":logger-coroutines:allTests" />
+                </list>
+            </option>
+            <option name="vmOptions" />
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <ForceTestExec>true</ForceTestExec>
+        <method v="2" />
+    </configuration>
 </component>

--- a/.idea/runConfigurations/All_Tests_Skip_Browser.xml
+++ b/.idea/runConfigurations/All_Tests_Skip_Browser.xml
@@ -1,25 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="All Tests - Skip Browser" type="GradleRunConfiguration" factoryName="Gradle">
-    <ExternalSystemSettings>
-      <option name="executionName" />
-      <option name="externalProjectPath" value="$PROJECT_DIR$" />
-      <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="--continue -x jsBrowserTest -x wasmJsBrowserTest" />
-      <option name="taskDescriptions">
-        <list />
-      </option>
-      <option name="taskNames">
-        <list>
-          <option value=":logger:allTests" />
-        </list>
-      </option>
-      <option name="vmOptions" />
-    </ExternalSystemSettings>
-    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
-    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-    <DebugAllEnabled>false</DebugAllEnabled>
-    <ForceTestExec>true</ForceTestExec>
-    <method v="2" />
-  </configuration>
+    <configuration name="All Tests - Skip Browser" default="false" factoryName="Gradle"
+        type="GradleRunConfiguration">
+        <ExternalSystemSettings>
+            <option name="executionName" />
+            <option name="externalProjectPath" value="$PROJECT_DIR$" />
+            <option name="externalSystemIdString" value="GRADLE" />
+            <option name="scriptParameters"
+                value="--continue -x jsBrowserTest -x wasmJsBrowserTest" />
+            <option name="taskDescriptions">
+                <list />
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value=":logger:allTests" />
+                    <option value=":logger-coroutines:allTests" />
+                </list>
+            </option>
+            <option name="vmOptions" />
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <ForceTestExec>true</ForceTestExec>
+        <method v="2" />
+    </configuration>
 </component>

--- a/README.MD
+++ b/README.MD
@@ -19,6 +19,7 @@ watchOS, tvOS, JVM, JS (Node.js & Browser), Wasm/JS, Linux, and MinGW.
 - [Core Concepts](#core-concepts)
 - [Configuration](#configuration)
 - [Log Context](#log-context)
+- [Coroutine Support](#coroutine-support)
 - [Log Formatters](#log-formatters)
 - [Available Sinks](#available-sinks)
 - [Simple vs Structured Logging](#simple-vs-structured-logging)
@@ -39,11 +40,13 @@ watchOS, tvOS, JVM, JS (Node.js & Browser), Wasm/JS, Linux, and MinGW.
 - **Structured Logging** - Attach typed key-value attributes to any log event
 - **Context Propagation** - Thread-local context on JVM/Android, `NSThread` dictionary on Apple,
   scoped save/restore everywhere else
+- **Coroutine-Aware Context** - Optional `logger-coroutines` module with `withLogContext` that
+  propagates `LogContext` safely across suspension points and thread hops on all platforms
 - **Lazy Evaluation** - Message lambda is never evaluated when the event would be filtered out
 - **Real Timestamps** - Epoch milliseconds captured on all platforms
 - **Thread Names** - Captured natively on Android, JVM, and Apple; `"main"` elsewhere
-- **Platform-Native Output** - Logcat on Android, `NSLog` on Apple, `console` on JS/Wasm, `stdout`on
-  JVM/Linux/MinGW
+- **Platform-Native Output** - Logcat on Android, `NSLog` on Apple, `console` on JS/Wasm,
+  `stdout` on JVM/Linux/MinGW
 - **Configurable Pipeline** - Per-tag level overrides, multiple sinks, custom formatters
 - **Built-in Formatters** - Default (human-readable), JSON (log aggregators), Compact, and Pretty
 - **Testable** - Built-in `TestSink` for asserting log output in unit tests
@@ -51,26 +54,39 @@ watchOS, tvOS, JVM, JS (Node.js & Browser), Wasm/JS, Linux, and MinGW.
 
 ## Installation
 
+### Core library
+
 ```kotlin
 // build.gradle.kts (commonMain)
 commonMain.dependencies {
-    implementation("io.github.shivathapaa:logger:1.3.0")
+    implementation("io.github.shivathapaa:logger:1.4.0")
 }
 ```
 
-For Android-only apps:
+### Coroutine support (optional)
+
+Add `logger-coroutines` if you use coroutines and need `LogContext` to survive suspension points
+and thread switches (e.g. `Dispatchers.IO` or `Dispatchers.Default` on JVM/Android):
+
+```kotlin
+// build.gradle.kts (commonMain)
+commonMain.dependencies {
+    implementation("io.github.shivathapaa:logger:1.4.0")
+    implementation("io.github.shivathapaa:logger-coroutines:1.4.0")
+}
+```
+
+For Android-only apps, platform-specific artifacts are also available:
 
 ```kotlin
 // build.gradle.kts (androidMain)
 androidMain.dependencies {
-    implementation("io.github.shivathapaa:logger-android:1.3.0")
+    implementation("io.github.shivathapaa:logger-android:1.4.0")
 }
 ```
 
-For platform-specific artifacts,
-see [Maven Central](https://central.sonatype.com/search?q=logger&namespace=io.github.shivathapaa).
-
-
+For the full list of platform-specific artifacts, see
+[Maven Central](https://central.sonatype.com/search?q=logger&namespace=io.github.shivathapaa).
 
 ## Simple Log API
 
@@ -278,8 +294,8 @@ val config = LoggerConfig.Builder()
 LoggerFactory.install(config)
 
 val networkLogger = LoggerFactory.get("NetworkModule") // uses DEBUG
-val sdkLogger = LoggerFactory.get("ThirdPartySDK") // uses ERROR
-val appLogger = LoggerFactory.get("MyApp")         // uses INFO (default)
+val sdkLogger = LoggerFactory.get("ThirdPartySDK")     // uses ERROR
+val appLogger = LoggerFactory.get("MyApp")             // uses INFO (default)
 ```
 
 ### Multiple Sinks
@@ -351,6 +367,125 @@ val result = LogContextHolder.withContext(context) {
 }
 ```
 
+## Coroutine Support
+
+KMP Logger ships with an optional `logger-coroutines` module that provides safe `LogContext`
+propagation across suspension points on all platforms.
+
+### The Problem
+
+`LogContextHolder.withContext` is synchronous. On JVM/Android, context is stored in a
+`ThreadLocal`. When a coroutine suspends and resumes on a different thread (e.g. with
+`Dispatchers.IO`), the `ThreadLocal` on the new thread is empty - the context is lost.
+
+### Solution: `withLogContext`
+
+The `logger-coroutines` module provides `withLogContext`, which solves this correctly on every
+platform:
+
+```kotlin
+import dev.shivathapaa.logger.coroutines.withLogContext
+
+suspend fun handleRequest(requestId: String) {
+    val ctx = LogContext(mapOf("requestId" to requestId))
+
+    withLogContext(ctx) {
+        logger.info { "Starting request" }
+
+        withContext(Dispatchers.IO) {       // thread hop - context still present
+            delay(100)                      // suspension - context still present
+            logger.debug { "Fetching data" }
+        }
+
+        logger.info { "Request complete" }
+    }
+}
+```
+
+### How It Works
+
+| Platform                    | Mechanism                                                                                                                                                                 |
+|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| JVM / Android               | `LogContextElement` implements `ThreadContextElement`. The coroutines dispatcher calls `updateThreadContext`/`restoreThreadContext` on every thread switch automatically. |
+| iOS / macOS / Apple         | Single-threaded. Context is set directly on `LogContextHolder` for the duration of the block and restored in `finally`.                                                   |
+| JS / WasmJS / Linux / MinGW | Single-threaded. Same approach as Apple.                                                                                                                                  |
+
+### Nesting and Merging
+
+`withLogContext` calls nest and merge just like `withContext`. Inner values override outer values
+for the same key:
+
+```kotlin
+withLogContext(LogContext(mapOf("traceId" to "trace-123"))) {
+    logger.info { "Outer" }  // traceId=trace-123
+
+    withLogContext(LogContext(mapOf("spanId" to "span-456"))) {
+        logger.info { "Inner" }  // traceId=trace-123, spanId=span-456
+    }
+
+    logger.info { "Back to outer" }  // traceId=trace-123
+}
+```
+
+### Attaching Context to a CoroutineScope
+
+To attach a fixed context to an entire scope, add `LogContextElement` directly to the scope's
+coroutine context:
+
+```kotlin
+import dev.shivathapaa.logger.coroutines.LogContextElement
+
+val scope = CoroutineScope(
+    Dispatchers.IO + LogContextElement(LogContext(mapOf("service" to "payment-api")))
+)
+
+scope.launch {
+    logger.info { "All coroutines in this scope carry service=payment-api" }
+}
+```
+
+### Accessing the Active Element
+
+Inside a `withLogContext` block you can read the current `LogContextElement` from the coroutine
+context:
+
+```kotlin
+withLogContext(LogContext(mapOf("requestId" to "req-1"))) {
+    val element = currentCoroutineContext()[LogContextElement]
+    println(element?.context)  // LogContext(values={requestId=req-1})
+}
+```
+
+### `withSuspendingContext` (core, limited)
+
+The core `logger` module also exposes `LogContextHolder.withSuspendingContext`. It accepts a
+suspending block but does **not** solve the thread-migration problem on JVM/Android - context is
+stored in a `ThreadLocal` and will be lost if the coroutine resumes on a different thread.
+
+Use `withSuspendingContext` only when:
+
+- The coroutine is pinned to a single thread (e.g. `Dispatchers.Main`), **or**
+- No thread-migration occurs in the block.
+
+For all other cases, use `withLogContext` from `logger-coroutines`.
+
+```kotlin
+// Safe on single-threaded dispatchers (Main, iOS, JS, etc.)
+LogContextHolder.withSuspendingContext(ctx) {
+    delay(100)
+    logger.info { "Context is present" }
+}
+```
+
+### Which API to Use
+
+| Scenario                                              | API                                          |
+|-------------------------------------------------------|----------------------------------------------|
+| Non-coroutine code                                    | `LogContextHolder.withContext`               |
+| Coroutine, single-threaded dispatcher only (Main, JS) | `LogContextHolder.withSuspendingContext`     |
+| Coroutine, any dispatcher / thread hops (IO, Default) | `withLogContext` from `logger-coroutines`    |
+| Fixed context on a whole scope                        | `LogContextElement` from `logger-coroutines` |
+
 ## Log Formatters
 
 Formatters convert a `LogEvent` into a string. Pass one to a sink. All built-in formatters
@@ -398,7 +533,7 @@ RemoteLogSink(
 ) { payload -> myApi.send(payload) }
 ```
 
-When `showEmoji = true`, the emoji is added as a `"levelEmoji"` field **inside** the JSON object —
+When `showEmoji = true`, the emoji is added as a `"levelEmoji"` field **inside** the JSON object -
 not prepended before it - so the output is always valid JSON:
 
 ```json
@@ -553,6 +688,25 @@ logger.info(
 ) { "Order created successfully" }
 ```
 
+### Coroutine Request Pipeline
+
+```kotlin
+suspend fun processOrder(orderId: String, userId: Int) {
+    val ctx = LogContext(mapOf("orderId" to orderId, "userId" to userId))
+
+    withLogContext(ctx) {
+        logger.info { "Processing order" }
+
+        val payment = withContext(Dispatchers.IO) {
+            logger.debug { "Charging payment" }  // context present on IO thread
+            chargePayment(orderId)
+        }
+
+        logger.info(attrs = { attr("paymentId", payment.id) }) { "Order complete" }
+    }
+}
+```
+
 ## Testing
 
 ### Unit Testing with TestSink
@@ -603,6 +757,29 @@ fun propagatesContextToNestedLogs() {
         assertEquals("req-123", event.context.values["requestId"])
     }
 }
+```
+
+### Testing Coroutine Context Propagation
+
+```kotlin
+@Test
+fun coroutineContextSurvivesSuspension() = runTest {
+        val testSink = TestSink()
+        LoggerFactory.install(
+            LoggerConfig.Builder()
+                .minLevel(LogLevel.DEBUG)
+                .addSink(testSink)
+                .build()
+        )
+        val logger = LoggerFactory.get("CoroutineTest")
+
+        withLogContext(LogContext(mapOf("requestId" to "req-123"))) {
+            delay(10)
+            logger.info { "After delay" }
+        }
+
+        assertEquals("req-123", testSink.events[0].context.values["requestId"])
+    }
 ```
 
 ## Advanced Topics
@@ -828,7 +1005,21 @@ logger.info(attrs = { attr("requestId", requestId) }) { "Starting request" }
 logger.info(attrs = { attr("requestId", requestId) }) { "Request completed" }
 ```
 
-### 5. Never Log Sensitive Information
+### 5. Use `withLogContext` in Coroutines
+
+```kotlin
+// Good - safe across thread hops and suspension
+withLogContext(LogContext(mapOf("requestId" to requestId))) {
+    withContext(Dispatchers.IO) { fetchData() }
+}
+
+// Risky on JVM/Android - context lost after thread switch
+LogContextHolder.withContext(LogContext(mapOf("requestId" to requestId))) {
+    withContext(Dispatchers.IO) { fetchData() } // context may be missing here
+}
+```
+
+### 6. Never Log Sensitive Information
 
 ```kotlin
 // Good
@@ -879,6 +1070,24 @@ LogContextHolder.withContext(context) {
 // Wrong - context object exists but is never applied
 val context = LogContext(mapOf("key" to "value"))
 logger.info { "No context" }
+```
+
+### Context Lost After Suspension (JVM/Android)
+
+If your context disappears after `delay()` or a thread switch on JVM/Android, you are using the
+synchronous `LogContextHolder.withContext` inside a coroutine. Switch to `withLogContext` from the
+`logger-coroutines` module:
+
+```kotlin
+// Before (context lost after thread switch on JVM/Android)
+LogContextHolder.withContext(ctx) {
+    withContext(Dispatchers.IO) { ... }
+}
+
+// After (context always present)
+withLogContext(ctx) {
+    withContext(Dispatchers.IO) { ... }
+}
 ```
 
 ## Contributing

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation(libs.kotlin.gradlePlugin)
+    implementation(libs.android.gradlePlugin)
+    implementation(libs.vanniktech.publish)
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,14 @@
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/kmplogger.kotlin-multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/kmplogger.kotlin-multiplatform.gradle.kts
@@ -1,0 +1,103 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    kotlin("multiplatform")
+    id("com.android.kotlin.multiplatform.library")
+}
+
+private val Project.libs
+    get(): VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+kotlin {
+    sourceSets {
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            implementation(libs.findLibrary("kotlinx-coroutines-test").get())
+        }
+
+        androidLibrary {
+            compileSdk = libs.findVersion("android-compileSdk").get().requiredVersion.toInt()
+            minSdk = libs.findVersion("android-minSdk").get().requiredVersion.toInt()
+
+            withJava()
+
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_11)
+            }
+
+            packaging {
+                resources {
+                    excludes += "/META-INF/{AL2.0,LGPL2.1}"
+                }
+            }
+        }
+    }
+
+    jvm {
+        testRuns["test"].executionTask.configure {
+            useJUnit()
+        }
+    }
+
+    js {
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                }
+            }
+        }
+        nodejs {
+            testTask {
+                useMocha {
+                    timeout = "60s"
+                }
+            }
+        }
+        useEsModules()
+        binaries.executable()
+        binaries.library()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                }
+            }
+        }
+        nodejs {
+            testTask {
+                useMocha {
+                    timeout = "60s"
+                }
+            }
+        }
+        binaries.executable()
+        binaries.library()
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosX64()
+    macosArm64()
+    linuxX64()
+    mingwX64()
+
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
+        compilations["main"].compileTaskProvider.configure {
+            compilerOptions {
+                freeCompilerArgs.add("-Xexport-kdoc")
+            }
+        }
+        compilations["test"].compileTaskProvider.configure {
+            compilerOptions {
+                freeCompilerArgs.add("-Xexport-kdoc")
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/kmplogger.maven-publish.gradle.kts
+++ b/build-logic/src/main/kotlin/kmplogger.maven-publish.gradle.kts
@@ -1,0 +1,49 @@
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SourcesJar
+
+plugins {
+    id("com.vanniktech.maven.publish")
+}
+
+mavenPublishing {
+    coordinates(
+        groupId = "io.github.shivathapaa",
+        artifactId = project.name,
+        version = providers.gradleProperty("kmplogger.version").get()
+    )
+
+    configure(KotlinMultiplatform(sourcesJar = SourcesJar.Sources()))
+
+    publishToMavenCentral()
+
+    if (providers.gradleProperty("signingInMemoryKey").isPresent ||
+        providers.environmentVariable("ORG_GRADLE_PROJECT_signingInMemoryKey").isPresent
+    ) {
+        signAllPublications()
+    }
+
+    pom {
+        name.set(project.name)
+        inceptionYear.set("2026")
+        url.set("https://github.com/shivathapaa/KMP-Logger")
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://opensource.org/licenses/MIT")
+            }
+        }
+        developers {
+            developer {
+                id.set("shivathapaa")
+                name.set("Shiva Thapa")
+                email.set("query.shivathapaa.dev@gmail.com")
+                url.set("https://github.com/shivathapaa/")
+            }
+        }
+        scm {
+            url.set("https://github.com/shivathapaa/KMP-Logger")
+            connection.set("scm:git:git://github.com/shivathapaa/KMP-Logger.git")
+            developerConnection.set("scm:git:ssh://github.com/shivathapaa/KMP-Logger.git")
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,5 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform).apply(false)
     alias(libs.plugins.composeMultiplatform).apply(false)
     alias(libs.plugins.compose.compiler).apply(false)
-    alias(libs.plugins.android.kotlin.multiplatform.library) apply false
-    alias(libs.plugins.maven.publish).apply(false)
     alias(libs.plugins.android.application).apply(false)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
+#KMP Logger
+kmplogger.version=1.3.0
+
 #Gradle
 org.gradle.jvmargs=-Xmx4G
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #KMP Logger
-kmplogger.version=1.3.0
+kmplogger.version=1.4.0
 
 #Gradle
 org.gradle.jvmargs=-Xmx4G

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "9.0.1"
+coroutines = "1.10.2"
 foundation = "1.10.3"
 kotlin = "2.3.20"
 android-minSdk = "24"
@@ -12,6 +13,7 @@ material3 = "1.9.0"
 
 [libraries]
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "foundation" }
 material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,11 @@ androidx-activityCompose = "1.13.0"
 material3 = "1.9.0"
 
 [libraries]
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+vanniktech-publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "foundation" }
 material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ kotlin = "2.3.20"
 android-minSdk = "24"
 android-compileSdk = "36"
 android-targetSdk = "36"
-logger = "1.2.1"
 maven-publish = "0.36.0"
 composeMultiplatform = "1.10.3"
 androidx-activityCompose = "1.13.0"
@@ -14,7 +13,6 @@ material3 = "1.9.0"
 [libraries]
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "foundation" }
-logger = { module = "io.github.shivathapaa:logger", version.ref = "logger" }
 material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
 ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/logger-coroutines/build.gradle.kts
+++ b/logger-coroutines/build.gradle.kts
@@ -1,0 +1,148 @@
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.SourcesJar
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.maven.publish)
+}
+
+group = "io.github.shivathapaa"
+version = "1.3.0"
+
+kotlin {
+    jvm {
+        testRuns["test"].executionTask.configure {
+            useJUnit()
+        }
+    }
+
+    js {
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                }
+            }
+        }
+        nodejs {
+            testTask {
+                useMocha {
+                    timeout = "60s"
+                }
+            }
+        }
+        useEsModules()
+        binaries.executable()
+        binaries.library()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                }
+            }
+        }
+        nodejs {
+            testTask {
+                useMocha {
+                    timeout = "60s"
+                }
+            }
+        }
+        binaries.executable()
+        binaries.library()
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosX64()
+    macosArm64()
+    linuxX64()
+    mingwX64()
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":logger"))
+            implementation(libs.kotlinx.coroutines.core)
+        }
+
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
+        }
+
+        androidLibrary {
+            namespace = "io.github.shivathapaa.logger.coroutines"
+            compileSdk = libs.versions.android.compileSdk.get().toInt()
+            minSdk = libs.versions.android.minSdk.get().toInt()
+
+            withJava()
+
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_11)
+            }
+
+            packaging {
+                resources {
+                    excludes += "/META-INF/{AL2.0,LGPL2.1}"
+                }
+            }
+        }
+    }
+
+    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
+        compilations["main"].compileTaskProvider.configure {
+            compilerOptions {
+                freeCompilerArgs.add("-Xexport-kdoc")
+            }
+        }
+        compilations["test"].compileTaskProvider.configure {
+            compilerOptions {
+                freeCompilerArgs.add("-Xexport-kdoc")
+            }
+        }
+    }
+}
+
+mavenPublishing {
+    coordinates(group.toString(), "logger-coroutines", version.toString())
+    configure(KotlinMultiplatform(sourcesJar = SourcesJar.Sources()))
+
+    pom {
+        name = "KMP Logger Coroutines"
+        description = "Coroutines support for KMP Logger  -  safe LogContext propagation across suspension points"
+        inceptionYear = "2026"
+        url = "https://github.com/shivathapaa/KMP-Logger"
+
+        licenses {
+            license {
+                name = "MIT"
+                url = "https://opensource.org/licenses/MIT"
+            }
+        }
+
+        developers {
+            developer {
+                id.set("shivathapaa")
+                name.set("Shiva Thapa")
+                email.set("query.shivathapaa.dev@gmail.com")
+                url.set("https://github.com/shivathapaa/")
+            }
+        }
+
+        scm {
+            url = "https://github.com/shivathapaa/KMP-Logger"
+        }
+    }
+
+    publishToMavenCentral()
+
+    signAllPublications()
+}

--- a/logger-coroutines/build.gradle.kts
+++ b/logger-coroutines/build.gradle.kts
@@ -1,148 +1,23 @@
-import com.vanniktech.maven.publish.KotlinMultiplatform
-import com.vanniktech.maven.publish.SourcesJar
-import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
-    alias(libs.plugins.maven.publish)
+    id("kmplogger.kotlin-multiplatform")
+    id("kmplogger.maven-publish")
 }
 
-group = "io.github.shivathapaa"
-version = "1.3.0"
-
 kotlin {
-    jvm {
-        testRuns["test"].executionTask.configure {
-            useJUnit()
-        }
-    }
-
-    js {
-        browser {
-            testTask {
-                useKarma {
-                    useChromeHeadless()
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "60s"
-                }
-            }
-        }
-        useEsModules()
-        binaries.executable()
-        binaries.library()
-    }
-
-    @OptIn(ExperimentalWasmDsl::class)
-    wasmJs {
-        browser {
-            testTask {
-                useKarma {
-                    useChromeHeadless()
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "60s"
-                }
-            }
-        }
-        binaries.executable()
-        binaries.library()
-    }
-
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
-
     sourceSets {
         commonMain.dependencies {
             implementation(project(":logger"))
             implementation(libs.kotlinx.coroutines.core)
         }
-
-        commonTest.dependencies {
-            implementation(kotlin("test"))
-            implementation(libs.kotlinx.coroutines.test)
-        }
-
         androidLibrary {
             namespace = "io.github.shivathapaa.logger.coroutines"
-            compileSdk = libs.versions.android.compileSdk.get().toInt()
-            minSdk = libs.versions.android.minSdk.get().toInt()
-
-            withJava()
-
-            compilerOptions {
-                jvmTarget.set(JvmTarget.JVM_11)
-            }
-
-            packaging {
-                resources {
-                    excludes += "/META-INF/{AL2.0,LGPL2.1}"
-                }
-            }
-        }
-    }
-
-    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
-        compilations["main"].compileTaskProvider.configure {
-            compilerOptions {
-                freeCompilerArgs.add("-Xexport-kdoc")
-            }
-        }
-        compilations["test"].compileTaskProvider.configure {
-            compilerOptions {
-                freeCompilerArgs.add("-Xexport-kdoc")
-            }
         }
     }
 }
 
 mavenPublishing {
-    coordinates(group.toString(), "logger-coroutines", version.toString())
-    configure(KotlinMultiplatform(sourcesJar = SourcesJar.Sources()))
-
     pom {
-        name = "KMP Logger Coroutines"
-        description = "Coroutines support for KMP Logger  -  safe LogContext propagation across suspension points"
-        inceptionYear = "2026"
-        url = "https://github.com/shivathapaa/KMP-Logger"
-
-        licenses {
-            license {
-                name = "MIT"
-                url = "https://opensource.org/licenses/MIT"
-            }
-        }
-
-        developers {
-            developer {
-                id.set("shivathapaa")
-                name.set("Shiva Thapa")
-                email.set("query.shivathapaa.dev@gmail.com")
-                url.set("https://github.com/shivathapaa/")
-            }
-        }
-
-        scm {
-            url = "https://github.com/shivathapaa/KMP-Logger"
-        }
+        name.set("KMP Logger Coroutines")
+        description.set("Coroutines support for KMP Logger - safe LogContext propagation across suspension points")
     }
-
-    publishToMavenCentral()
-
-    signAllPublications()
 }

--- a/logger-coroutines/src/androidMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.android.kt
+++ b/logger-coroutines/src/androidMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.android.kt
@@ -1,0 +1,27 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.InternalLoggerApi
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.ThreadContextElement
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+actual class LogContextElement actual constructor(actual val context: LogContext) :
+    ThreadContextElement<LogContext>,
+    AbstractCoroutineContextElement(Key) {
+
+    actual companion object Key : CoroutineContext.Key<LogContextElement>
+
+    @OptIn(InternalLoggerApi::class)
+    override fun updateThreadContext(context: CoroutineContext): LogContext {
+        val previous = LogContextHolder.current()
+        LogContextHolder.setContext(this.context)
+        return previous
+    }
+
+    @OptIn(InternalLoggerApi::class)
+    override fun restoreThreadContext(context: CoroutineContext, oldState: LogContext) {
+        LogContextHolder.setContext(oldState)
+    }
+}

--- a/logger-coroutines/src/androidMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.android.kt
+++ b/logger-coroutines/src/androidMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.android.kt
@@ -1,0 +1,10 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.withContext
+
+actual suspend fun <T> withLogContext(ctx: LogContext, block: suspend () -> T): T {
+    val merged = LogContextHolder.current().merge(ctx)
+    return withContext(LogContextElement(merged)) { block() }
+}

--- a/logger-coroutines/src/appleMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.apple.kt
+++ b/logger-coroutines/src/appleMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.apple.kt
@@ -1,0 +1,11 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+actual class LogContextElement actual constructor(actual val context: LogContext) :
+    AbstractCoroutineContextElement(Key) {
+
+    actual companion object Key : CoroutineContext.Key<LogContextElement>
+}

--- a/logger-coroutines/src/appleMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.apple.kt
+++ b/logger-coroutines/src/appleMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.apple.kt
@@ -1,0 +1,18 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.InternalLoggerApi
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.withContext
+
+@OptIn(InternalLoggerApi::class)
+actual suspend fun <T> withLogContext(ctx: LogContext, block: suspend () -> T): T {
+    val merged = LogContextHolder.current().merge(ctx)
+    val previous = LogContextHolder.current()
+    LogContextHolder.setContext(merged)
+    return try {
+        withContext(LogContextElement(merged)) { block() }
+    } finally {
+        LogContextHolder.setContext(previous)
+    }
+}

--- a/logger-coroutines/src/commonMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.kt
+++ b/logger-coroutines/src/commonMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.kt
@@ -1,0 +1,48 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A [CoroutineContext.Element] that carries a [LogContext] through a coroutine's lifetime.
+ *
+ * ### JVM and Android
+ * Also implements `ThreadContextElement<LogContext>`. The coroutine dispatcher automatically
+ * calls [LogContextHolder.setContext][dev.shivathapaa.logger.core.LogContextHolder.setContext]
+ * via `updateThreadContext` before each dispatch and restores the previous context via
+ * `restoreThreadContext` after. This means the [LogContext] is correctly visible in
+ * [LogContextHolder.current()][dev.shivathapaa.logger.core.LogContextHolder.current] on
+ * every thread the coroutine runs on, including after suspension points that hop to a
+ * different thread-pool thread (e.g. `Dispatchers.IO` or `Dispatchers.Default`).
+ * Concurrent coroutines on JVM are also fully isolated from each other.
+ *
+ * ### Other platforms (JS, WasmJS, iOS, macOS, Linux, MinGW)
+ * Coroutines are single-threaded. The element stores the [LogContext] value in the
+ * coroutine context for inspection via `coroutineContext[LogContextElement]`.
+ * [withLogContext] installs the context into [LogContextHolder] for the duration of
+ * the block, but concurrent coroutines that interleave via suspension points share
+ * the same context slot and are not isolated from each other.
+ *
+ * ### Accessing the element
+ * The active element is always retrievable from inside a [withLogContext] block:
+ * ```kotlin
+ * withLogContext(LogContext(mapOf("requestId" to "req-1"))) {
+ *     val element = kotlinx.coroutines.currentCoroutineContext()[LogContextElement]
+ *     println(element?.context)  // LogContext(values={requestId=req-1})
+ * }
+ * ```
+ *
+ * Prefer [withLogContext] over constructing this element directly. Direct construction
+ * is useful when attaching a context to an entire [kotlinx.coroutines.CoroutineScope]:
+ * ```kotlin
+ * val scope = CoroutineScope(
+ *     Dispatchers.IO + LogContextElement(LogContext(mapOf("service" to "api")))
+ * )
+ * ```
+ */
+expect class LogContextElement(context: LogContext) : CoroutineContext.Element {
+    val context: LogContext
+    override val key: CoroutineContext.Key<*>
+
+    companion object Key : CoroutineContext.Key<LogContextElement>
+}

--- a/logger-coroutines/src/commonMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.kt
+++ b/logger-coroutines/src/commonMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.kt
@@ -1,0 +1,38 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+
+/**
+ * Executes [block] with [ctx] merged into the current log context, propagating it
+ * correctly across suspension points on all platforms.
+ *
+ * On **JVM and Android** the merged context is stored as a
+ * [LogContextElement] (a `ThreadContextElement`) in the coroutine context.
+ * The coroutines runtime installs and restores it via
+ * [LogContextHolder][dev.shivathapaa.logger.core.LogContextHolder] on every thread
+ * the coroutine resumes on, so it works correctly with `Dispatchers.IO`,
+ * `Dispatchers.Default`, and any other multi-threaded dispatcher.
+ *
+ * On **JS, WasmJS, iOS, macOS, Linux, and MinGW** the context is set directly
+ * on [LogContextHolder][dev.shivathapaa.logger.core.LogContextHolder] for the
+ * duration of the block (safe because those platforms are single-threaded).
+ *
+ * The previous context is always restored after [block] completes, even if
+ * [block] throws.
+ *
+ * Nested calls merge their contexts  -  inner values override outer values for
+ * the same key.
+ *
+ * Example:
+ * ```kotlin
+ * withLogContext(LogContext(mapOf("requestId" to "req-123"))) {
+ *     delay(100) // safe  -  context survives the suspension
+ *     logger.info { "Handling request" }
+ * }
+ * ```
+ *
+ * @param ctx The context to merge into the current context for the duration of [block].
+ * @param block The suspending block to execute within the merged context.
+ * @return The value returned by [block].
+ */
+expect suspend fun <T> withLogContext(ctx: LogContext, block: suspend () -> T): T

--- a/logger-coroutines/src/commonTest/kotlin/dev/shivathapaa/logger/coroutines/LogContextElementTest.kt
+++ b/logger-coroutines/src/commonTest/kotlin/dev/shivathapaa/logger/coroutines/LogContextElementTest.kt
@@ -1,0 +1,135 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// Top-level helper: captures currentCoroutineContext() without being shadowed
+// by coroutineContext from an enclosing runTest lambda.
+private suspend fun currentCoroutineContext(): CoroutineContext = currentCoroutineContext()
+
+class LogContextElementTest {
+
+    // Construction
+    @Test
+    fun contextPropertyReflectsConstructorArg() {
+        val ctx = LogContext(mapOf("requestId" to "req-1"))
+        val element = LogContextElement(ctx)
+        assertEquals(ctx.values, element.context.values)
+    }
+
+    @Test
+    fun contextPropertyWithEmptyLogContext() {
+        val element = LogContextElement(LogContext())
+        assertTrue(element.context.values.isEmpty())
+    }
+
+    @Test
+    fun contextPropertyRetainsMultipleValues() {
+        val values = mapOf("traceId" to "t-1", "spanId" to "s-1", "userId" to "u-99")
+        val element = LogContextElement(LogContext(values))
+        assertEquals(values, element.context.values)
+    }
+
+    // Key 
+
+    @Test
+    fun keyIsLogContextElementCompanionKey() {
+        val element = LogContextElement(LogContext(mapOf("k" to "v")))
+        assertEquals(LogContextElement.Key, element.key)
+    }
+
+    @Test
+    fun companionKeyAndClassRefResolveToSameKey() {
+        assertEquals(LogContextElement.Key, LogContextElement)
+    }
+
+    // Coroutine-context lookup
+    @Test
+    fun elementRetrievableFromCoroutineContextByCompanionKey() = runTest {
+        val ctx = LogContext(mapOf("userId" to "u-1"))
+        withLogContext(ctx) {
+            yield()
+            val element = currentCoroutineContext()[LogContextElement.Key]
+            assertNotNull(element)
+            assertEquals("u-1", element.context.values["userId"])
+        }
+    }
+
+    @Test
+    fun elementRetrievableFromCoroutineContextByClassRef() = runTest {
+        val ctx = LogContext(mapOf("service" to "api"))
+        withLogContext(ctx) {
+            yield()
+            val element = currentCoroutineContext()[LogContextElement]
+            assertNotNull(element)
+            assertEquals("api", element.context.values["service"])
+        }
+    }
+
+    @Test
+    fun elementNotPresentInCoroutineContextOutsideWithLogContext() = runTest {
+        val element = currentCoroutineContext()[LogContextElement]
+        assertNull(element)
+    }
+
+    // Element context matches LogContextHolder
+    @Test
+    fun elementContextMatchesLogContextHolder() = runTest {
+        val ctx = LogContext(mapOf("env" to "prod"))
+        withLogContext(ctx) {
+            yield()
+            val element = currentCoroutineContext()[LogContextElement]
+            assertNotNull(element)
+            assertEquals(LogContextHolder.current().values, element.context.values)
+        }
+    }
+
+    @Test
+    fun nestedElementContextContainsMergedValues() = runTest {
+        val outer = LogContext(mapOf("traceId" to "t-1"))
+        val inner = LogContext(mapOf("spanId" to "s-1"))
+
+        withLogContext(outer) {
+            withLogContext(inner) {
+                yield()
+                val element = currentCoroutineContext()[LogContextElement]
+                assertNotNull(element)
+                assertEquals("t-1", element.context.values["traceId"])
+                assertEquals("s-1", element.context.values["spanId"])
+            }
+        }
+    }
+
+    @Test
+    fun elementContextInOuterScopeDoesNotContainInnerKeys() = runTest {
+        val outer = LogContext(mapOf("traceId" to "t-1"))
+        val inner = LogContext(mapOf("spanId" to "s-1"))
+
+        withLogContext(outer) {
+            withLogContext(inner) { yield() }
+            yield()
+            val element = currentCoroutineContext()[LogContextElement]
+            assertNotNull(element)
+            assertEquals("t-1", element.context.values["traceId"])
+            assertNull(element.context.values["spanId"])
+        }
+    }
+
+    // Two distinct instances
+    @Test
+    fun twoElementInstancesWithDifferentContextsAreDistinct() {
+        val a = LogContextElement(LogContext(mapOf("k" to "a")))
+        val b = LogContextElement(LogContext(mapOf("k" to "b")))
+        assertEquals("a", a.context.values["k"])
+        assertEquals("b", b.context.values["k"])
+    }
+}

--- a/logger-coroutines/src/commonTest/kotlin/dev/shivathapaa/logger/coroutines/WithLogContextTest.kt
+++ b/logger-coroutines/src/commonTest/kotlin/dev/shivathapaa/logger/coroutines/WithLogContextTest.kt
@@ -1,0 +1,269 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// Top-level helper: captures currentCoroutineContext without being shadowed
+// by coroutineContext from an enclosing runTest lambda.
+private suspend fun currentCoroutineContext(): CoroutineContext = currentCoroutineContext()
+
+class WithLogContextTest {
+
+    @Test
+    fun withLogContextInstallsContext() = runTest {
+        val ctx = LogContext(mapOf("requestId" to "req-1"))
+
+        withLogContext(ctx) {
+            yield()
+            assertEquals("req-1", LogContextHolder.current().values["requestId"])
+        }
+    }
+
+    @Test
+    fun withLogContextRestoresPreviousContextAfterBlock() = runTest {
+        val ctx = LogContext(mapOf("requestId" to "req-1"))
+
+        withLogContext(ctx) { yield() }
+
+        assertTrue(LogContextHolder.current().values.isEmpty())
+    }
+
+    @Test
+    fun withLogContextRestoresContextOnException() = runTest {
+        val ctx = LogContext(mapOf("requestId" to "req-1"))
+
+        assertFailsWith<RuntimeException> {
+            withLogContext(ctx) {
+                yield()
+                throw RuntimeException("test error")
+            }
+        }
+
+        assertTrue(LogContextHolder.current().values.isEmpty())
+    }
+
+    @Test
+    fun withLogContextPropagatesReturnValue() = runTest {
+        val ctx = LogContext(mapOf("k" to "v"))
+
+        val result = withLogContext(ctx) {
+            yield()
+            42
+        }
+
+        assertEquals(42, result)
+    }
+
+    @Test
+    fun nestedWithLogContextMergesContexts() = runTest {
+        val outer = LogContext(mapOf("traceId" to "t-1"))
+        val inner = LogContext(mapOf("spanId" to "s-1"))
+
+        withLogContext(outer) {
+            withLogContext(inner) {
+                yield()
+                val current = LogContextHolder.current()
+                assertEquals("t-1", current.values["traceId"])
+                assertEquals("s-1", current.values["spanId"])
+            }
+        }
+    }
+
+    @Test
+    fun nestedWithLogContextInnerOverridesOuterOnKeyCollision() = runTest {
+        val outer = LogContext(mapOf("env" to "prod"))
+        val inner = LogContext(mapOf("env" to "test"))
+
+        withLogContext(outer) {
+            withLogContext(inner) {
+                yield()
+                assertEquals("test", LogContextHolder.current().values["env"])
+            }
+            yield()
+            assertEquals("prod", LogContextHolder.current().values["env"])
+        }
+    }
+
+    @Test
+    fun outerContextRestoredAfterNestedBlock() = runTest {
+        val outer = LogContext(mapOf("traceId" to "t-1"))
+        val inner = LogContext(mapOf("spanId" to "s-1"))
+
+        withLogContext(outer) {
+            withLogContext(inner) { yield() }
+            yield()
+            val current = LogContextHolder.current()
+            assertEquals("t-1", current.values["traceId"])
+            assertEquals(null, current.values["spanId"])
+        }
+    }
+
+    @Test
+    fun logContextElementCanBeReadFromCoroutineContext() = runTest {
+        val ctx = LogContext(mapOf("userId" to "u-1"))
+
+        withLogContext(ctx) {
+            yield()
+            val element = currentCoroutineContext()[LogContextElement]
+            assertEquals("u-1", element?.context?.values?.get("userId"))
+        }
+    }
+
+    // Empty input 
+
+    @Test
+    fun withLogContextEmptyCtxDoesNotAddValues() = runTest {
+        withLogContext(LogContext()) {
+            yield()
+            assertTrue(LogContextHolder.current().values.isEmpty())
+        }
+    }
+
+    @Test
+    fun withLogContextEmptyCtxPreservesExistingOuterValues() = runTest {
+        val outer = LogContext(mapOf("traceId" to "t-1"))
+        withLogContext(outer) {
+            withLogContext(LogContext()) {
+                yield()
+                assertEquals("t-1", LogContextHolder.current().values["traceId"])
+                assertEquals(1, LogContextHolder.current().values.size)
+            }
+        }
+    }
+
+    // Multiple keys in one call 
+
+    @Test
+    fun withLogContextMultipleKeysAllVisibleInsideBlock() = runTest {
+        val ctx = LogContext(mapOf("traceId" to "t-1", "spanId" to "s-2", "userId" to "u-3"))
+
+        withLogContext(ctx) {
+            yield()
+            val current = LogContextHolder.current()
+            assertEquals("t-1", current.values["traceId"])
+            assertEquals("s-2", current.values["spanId"])
+            assertEquals("u-3", current.values["userId"])
+        }
+    }
+
+    @Test
+    fun withLogContextMultipleKeysAllRemovedAfterBlock() = runTest {
+        val ctx = LogContext(mapOf("a" to "1", "b" to "2", "c" to "3"))
+
+        withLogContext(ctx) { yield() }
+
+        val current = LogContextHolder.current()
+        assertNull(current.values["a"])
+        assertNull(current.values["b"])
+        assertNull(current.values["c"])
+    }
+
+    // Deep nesting 
+
+    @Test
+    fun withLogContextThreeLevelsDeepMergesAllContexts() = runTest {
+        val level1 = LogContext(mapOf("level" to "1", "l1" to "a"))
+        val level2 = LogContext(mapOf("level" to "2", "l2" to "b"))
+        val level3 = LogContext(mapOf("level" to "3", "l3" to "c"))
+
+        withLogContext(level1) {
+            withLogContext(level2) {
+                withLogContext(level3) {
+                    yield()
+                    val current = LogContextHolder.current()
+                    assertEquals("3", current.values["level"]) // innermost wins
+                    assertEquals("a", current.values["l1"])
+                    assertEquals("b", current.values["l2"])
+                    assertEquals("c", current.values["l3"])
+                }
+                yield()
+                val current = LogContextHolder.current()
+                assertEquals("2", current.values["level"])
+                assertEquals("a", current.values["l1"])
+                assertEquals("b", current.values["l2"])
+                assertNull(current.values["l3"])
+            }
+            yield()
+            val current = LogContextHolder.current()
+            assertEquals("1", current.values["level"])
+            assertEquals("a", current.values["l1"])
+            assertNull(current.values["l2"])
+            assertNull(current.values["l3"])
+        }
+    }
+
+    @Test
+    fun withLogContextThreeLevelsRestoredToEmptyAfterAll() = runTest {
+        withLogContext(LogContext(mapOf("a" to "1"))) {
+            withLogContext(LogContext(mapOf("b" to "2"))) {
+                withLogContext(LogContext(mapOf("c" to "3"))) { yield() }
+            }
+        }
+        assertTrue(LogContextHolder.current().values.isEmpty())
+    }
+
+    @Test
+    fun withLogContextExceptionInDeepNestRestoresAllLevels() = runTest {
+        assertFailsWith<RuntimeException> {
+            withLogContext(LogContext(mapOf("a" to "1"))) {
+                withLogContext(LogContext(mapOf("b" to "2"))) {
+                    withLogContext(LogContext(mapOf("c" to "3"))) {
+                        yield()
+                        throw RuntimeException("deep failure")
+                    }
+                }
+            }
+        }
+        assertTrue(LogContextHolder.current().values.isEmpty())
+    }
+
+    // Coroutine-context element carries merged values 
+
+    @Test
+    fun coroutineContextElementHasAllMergedValues() = runTest {
+        val outer = LogContext(mapOf("traceId" to "t-1", "shared" to "outer"))
+        val inner = LogContext(mapOf("spanId" to "s-1", "shared" to "inner"))
+
+        withLogContext(outer) {
+            withLogContext(inner) {
+                yield()
+                val element = currentCoroutineContext()[LogContextElement]
+                assertNotNull(element)
+                assertEquals("t-1", element.context.values["traceId"])
+                assertEquals("s-1", element.context.values["spanId"])
+                assertEquals("inner", element.context.values["shared"])
+            }
+        }
+    }
+
+    // Return value edge cases 
+
+    @Test
+    fun withLogContextReturnsNullableValue() = runTest {
+        val result: String? = withLogContext(LogContext(mapOf("k" to "v"))) {
+            yield()
+            null
+        }
+        assertNull(result)
+    }
+
+    @Test
+    fun withLogContextReturnsUnitImplicitly() = runTest {
+        var executed = false
+        withLogContext(LogContext(mapOf("k" to "v"))) {
+            yield()
+            executed = true
+        }
+        assertTrue(executed)
+    }
+}

--- a/logger-coroutines/src/jsMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.js.kt
+++ b/logger-coroutines/src/jsMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.js.kt
@@ -1,0 +1,11 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+actual class LogContextElement actual constructor(actual val context: LogContext) :
+    AbstractCoroutineContextElement(Key) {
+
+    actual companion object Key : CoroutineContext.Key<LogContextElement>
+}

--- a/logger-coroutines/src/jsMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.js.kt
+++ b/logger-coroutines/src/jsMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.js.kt
@@ -1,0 +1,18 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.InternalLoggerApi
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.withContext
+
+@OptIn(InternalLoggerApi::class)
+actual suspend fun <T> withLogContext(ctx: LogContext, block: suspend () -> T): T {
+    val merged = LogContextHolder.current().merge(ctx)
+    val previous = LogContextHolder.current()
+    LogContextHolder.setContext(merged)
+    return try {
+        withContext(LogContextElement(merged)) { block() }
+    } finally {
+        LogContextHolder.setContext(previous)
+    }
+}

--- a/logger-coroutines/src/jvmMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.jvm.kt
+++ b/logger-coroutines/src/jvmMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.jvm.kt
@@ -1,0 +1,27 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.InternalLoggerApi
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.ThreadContextElement
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+actual class LogContextElement actual constructor(actual val context: LogContext) :
+    ThreadContextElement<LogContext>,
+    AbstractCoroutineContextElement(Key) {
+
+    actual companion object Key : CoroutineContext.Key<LogContextElement>
+
+    @OptIn(InternalLoggerApi::class)
+    override fun updateThreadContext(context: CoroutineContext): LogContext {
+        val previous = LogContextHolder.current()
+        LogContextHolder.setContext(this.context)
+        return previous
+    }
+
+    @OptIn(InternalLoggerApi::class)
+    override fun restoreThreadContext(context: CoroutineContext, oldState: LogContext) {
+        LogContextHolder.setContext(oldState)
+    }
+}

--- a/logger-coroutines/src/jvmMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.jvm.kt
+++ b/logger-coroutines/src/jvmMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.jvm.kt
@@ -1,0 +1,10 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.withContext
+
+actual suspend fun <T> withLogContext(ctx: LogContext, block: suspend () -> T): T {
+    val merged = LogContextHolder.current().merge(ctx)
+    return withContext(LogContextElement(merged)) { block() }
+}

--- a/logger-coroutines/src/jvmTest/kotlin/dev/shivathapaa/logger/coroutines/WithLogContextConcurrencyTest.kt
+++ b/logger-coroutines/src/jvmTest/kotlin/dev/shivathapaa/logger/coroutines/WithLogContextConcurrencyTest.kt
@@ -1,0 +1,68 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// JVM-only: ThreadContextElement guarantees context isolation across concurrent coroutines
+// even when they yield and are interleaved on the same or different threads. This is a
+// JVM/Android feature single-threaded platforms share one context slot and cannot
+// isolate concurrent coroutines this way.
+class WithLogContextConcurrencyTest {
+
+    @Test
+    fun withLogContextConcurrentCoroutinesHaveIsolatedContexts() = runTest {
+        val results = (0 until 3).map { i ->
+            async {
+                withLogContext(LogContext(mapOf("coroutineId" to "$i"))) {
+                    yield()
+                    LogContextHolder.current().values["coroutineId"]
+                }
+            }
+        }.awaitAll()
+
+        assertEquals(listOf("0", "1", "2"), results)
+    }
+
+    @Test
+    fun withLogContextConcurrentCoroutinesDoNotLeakContextToSiblings() = runTest {
+        val results = (0 until 3).map { i ->
+            async {
+                withLogContext(LogContext(mapOf("id" to "$i", "only-$i" to "yes"))) {
+                    yield()
+                    val sibling = (i + 1) % 3
+                    LogContextHolder.current().values["only-$sibling"]
+                }
+            }
+        }.awaitAll()
+
+        assertTrue(results.all { it == null })
+    }
+
+    @Test
+    fun withLogContextContextRestoredAfterConcurrentCoroutineCompletes() = runTest {
+        val deferred = async {
+            withLogContext(LogContext(mapOf("bg" to "job"))) {
+                yield()
+                LogContextHolder.current().values["bg"]
+            }
+        }
+
+        withLogContext(LogContext(mapOf("fg" to "main"))) {
+            yield()
+            assertEquals("main", LogContextHolder.current().values["fg"])
+            assertNull(LogContextHolder.current().values["bg"])
+        }
+
+        assertEquals("job", deferred.await())
+        assertNull(LogContextHolder.current().values["bg"])
+        assertNull(LogContextHolder.current().values["fg"])
+    }
+}

--- a/logger-coroutines/src/linuxMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.linux.kt
+++ b/logger-coroutines/src/linuxMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.linux.kt
@@ -1,0 +1,11 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+actual class LogContextElement actual constructor(actual val context: LogContext) :
+    AbstractCoroutineContextElement(Key) {
+
+    actual companion object Key : CoroutineContext.Key<LogContextElement>
+}

--- a/logger-coroutines/src/linuxMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.linux.kt
+++ b/logger-coroutines/src/linuxMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.linux.kt
@@ -1,0 +1,18 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.InternalLoggerApi
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.withContext
+
+@OptIn(InternalLoggerApi::class)
+actual suspend fun <T> withLogContext(ctx: LogContext, block: suspend () -> T): T {
+    val merged = LogContextHolder.current().merge(ctx)
+    val previous = LogContextHolder.current()
+    LogContextHolder.setContext(merged)
+    return try {
+        withContext(LogContextElement(merged)) { block() }
+    } finally {
+        LogContextHolder.setContext(previous)
+    }
+}

--- a/logger-coroutines/src/mingwMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.mingw.kt
+++ b/logger-coroutines/src/mingwMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.mingw.kt
@@ -1,0 +1,11 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+actual class LogContextElement actual constructor(actual val context: LogContext) :
+    AbstractCoroutineContextElement(Key) {
+
+    actual companion object Key : CoroutineContext.Key<LogContextElement>
+}

--- a/logger-coroutines/src/mingwMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.mingw.kt
+++ b/logger-coroutines/src/mingwMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.mingw.kt
@@ -1,0 +1,18 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.InternalLoggerApi
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.withContext
+
+@OptIn(InternalLoggerApi::class)
+actual suspend fun <T> withLogContext(ctx: LogContext, block: suspend () -> T): T {
+    val merged = LogContextHolder.current().merge(ctx)
+    val previous = LogContextHolder.current()
+    LogContextHolder.setContext(merged)
+    return try {
+        withContext(LogContextElement(merged)) { block() }
+    } finally {
+        LogContextHolder.setContext(previous)
+    }
+}

--- a/logger-coroutines/src/wasmJsMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.wasmJs.kt
+++ b/logger-coroutines/src/wasmJsMain/kotlin/dev/shivathapaa/logger/coroutines/LogContextElement.wasmJs.kt
@@ -1,0 +1,11 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.LogContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+actual class LogContextElement actual constructor(actual val context: LogContext) :
+    AbstractCoroutineContextElement(Key) {
+
+    actual companion object Key : CoroutineContext.Key<LogContextElement>
+}

--- a/logger-coroutines/src/wasmJsMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.wasmJs.kt
+++ b/logger-coroutines/src/wasmJsMain/kotlin/dev/shivathapaa/logger/coroutines/withLogContext.wasmJs.kt
@@ -1,0 +1,18 @@
+package dev.shivathapaa.logger.coroutines
+
+import dev.shivathapaa.logger.core.InternalLoggerApi
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.withContext
+
+@OptIn(InternalLoggerApi::class)
+actual suspend fun <T> withLogContext(ctx: LogContext, block: suspend () -> T): T {
+    val merged = LogContextHolder.current().merge(ctx)
+    val previous = LogContextHolder.current()
+    LogContextHolder.setContext(merged)
+    return try {
+        withContext(LogContextElement(merged)) { block() }
+    } finally {
+        LogContextHolder.setContext(previous)
+    }
+}

--- a/logger/build.gradle.kts
+++ b/logger/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
     sourceSets {
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
         }
 
         androidLibrary {

--- a/logger/build.gradle.kts
+++ b/logger/build.gradle.kts
@@ -1,142 +1,22 @@
-import com.vanniktech.maven.publish.KotlinMultiplatform
-import com.vanniktech.maven.publish.SourcesJar
-import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
-    alias(libs.plugins.maven.publish)
+    id("kmplogger.kotlin-multiplatform")
+    id("kmplogger.maven-publish")
 }
-
-group = "io.github.shivathapaa"
-version = "1.3.0"
 
 kotlin {
     sourceSets {
-        commonTest.dependencies {
-            implementation(kotlin("test"))
-            implementation(libs.kotlinx.coroutines.test)
-        }
-
         androidLibrary {
             namespace = "io.github.shivathapaa.logger"
-            compileSdk = libs.versions.android.compileSdk.get().toInt()
-            minSdk = libs.versions.android.minSdk.get().toInt()
-
-            withJava() // enable java compilation support
-
-            compilerOptions {
-                jvmTarget.set(JvmTarget.JVM_11)
-            }
-
-            packaging {
-                resources {
-                    excludes += "/META-INF/{AL2.0,LGPL2.1}"
-                }
-            }
-        }
-    }
-    jvm {
-        testRuns["test"].executionTask.configure {
-            useJUnit()
-        }
-    }
-
-    js {
-        browser {
-            testTask {
-                useKarma {
-                    useChromeHeadless() // requires Chrome installed; skip with -x jsBrowserTest
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "60s"
-                }
-            }
-        }
-        useEsModules()
-        binaries.executable()
-        binaries.library()
-    }
-
-    @OptIn(ExperimentalWasmDsl::class)
-    wasmJs {
-        browser {
-            testTask {
-                useKarma {
-                    useChromeHeadless() // requires Chrome installed; skip with -x wasmJsBrowserTest
-                }
-            }
-        }
-        nodejs {
-            testTask {
-                useMocha {
-                    timeout = "60s"
-                }
-            }
-        }
-        binaries.executable()
-        binaries.library()
-    }
-
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-    macosX64()
-    macosArm64()
-    linuxX64()
-    mingwX64()
-
-    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
-        compilations["main"].compileTaskProvider.configure {
-            compilerOptions {
-                freeCompilerArgs.add("-Xexport-kdoc")
-            }
-        }
-        compilations["test"].compileTaskProvider.configure {
-            compilerOptions {
-                freeCompilerArgs.add("-Xexport-kdoc")
-            }
         }
     }
 }
 
 mavenPublishing {
-    coordinates(group.toString(), "logger", version.toString())
-    configure(KotlinMultiplatform(sourcesJar = SourcesJar.Sources()))
-
     pom {
-        name = "KMP Logger"
-        description = "Kotlin Multiplatform logger"
-        inceptionYear = "2026"
-        url = "https://github.com/shivathapaa/KMP-Logger"
-
-        licenses {
-            license {
-                name = "MIT"
-                url = "https://opensource.org/licenses/MIT"
-            }
-        }
-
-        developers {
-            developer {
-                id.set("shivathapaa")
-                name.set("Shiva Thapa")
-                email.set("query.shivathapaa.dev@gmail.com")
-                url.set("https://github.com/shivathapaa/")
-            }
-        }
-
-        scm {
-            url = "https://github.com/shivathapaa/KMP-Logger"
-        }
+        name.set("KMP Logger")
+        description.set(
+            "Kotlin Multiplatform logger - A lightweight, structured logging library for Kotlin Multiplatform. Supports Android, iOS, macOS,\n" +
+                    "watchOS, tvOS, JVM, JS (Node.js & Browser), Wasm/JS, Linux, and MinGW."
+        )
     }
-
-    publishToMavenCentral()
-
-    signAllPublications()
 }

--- a/logger/src/androidMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.android.kt
+++ b/logger/src/androidMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.android.kt
@@ -24,4 +24,9 @@ actual object LogContextHolder {
             holder.set(previous)
         }
     }
+
+    @InternalLoggerApi
+    actual fun setContext(ctx: LogContext) {
+        if (ctx.values.isEmpty()) holder.remove() else holder.set(ctx)
+    }
 }

--- a/logger/src/androidMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.android.kt
+++ b/logger/src/androidMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.android.kt
@@ -14,4 +14,14 @@ actual object LogContextHolder {
             holder.set(previous)
         }
     }
+
+    actual suspend fun <T> withSuspendingContext(ctx: LogContext, block: suspend () -> T): T {
+        val previous = current()
+        holder.set(previous.merge(ctx))
+        try {
+            return block()
+        } finally {
+            holder.set(previous)
+        }
+    }
 }

--- a/logger/src/appleMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.ios.kt
+++ b/logger/src/appleMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.ios.kt
@@ -41,4 +41,13 @@ actual object LogContextHolder {
             }
         }
     }
+
+    @InternalLoggerApi
+    actual fun setContext(ctx: LogContext) {
+        if (ctx.values.isEmpty()) {
+            NSThread.currentThread.threadDictionary.removeObjectForKey(nsKey)
+        } else {
+            NSThread.currentThread.threadDictionary.setObject(ctx, forKey = nsKey)
+        }
+    }
 }

--- a/logger/src/appleMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.ios.kt
+++ b/logger/src/appleMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.ios.kt
@@ -26,4 +26,19 @@ actual object LogContextHolder {
             }
         }
     }
+
+    actual suspend fun <T> withSuspendingContext(ctx: LogContext, block: suspend () -> T): T {
+        val previous = current()
+        val merged = previous.merge(ctx)
+        NSThread.currentThread.threadDictionary.setObject(merged, forKey = nsKey)
+        try {
+            return block()
+        } finally {
+            if (previous.values.isEmpty()) {
+                NSThread.currentThread.threadDictionary.removeObjectForKey(nsKey)
+            } else {
+                NSThread.currentThread.threadDictionary.setObject(previous, forKey = nsKey)
+            }
+        }
+    }
 }

--- a/logger/src/commonMain/kotlin/dev/shivathapaa/logger/core/InternalLoggerApi.kt
+++ b/logger/src/commonMain/kotlin/dev/shivathapaa/logger/core/InternalLoggerApi.kt
@@ -1,0 +1,24 @@
+package dev.shivathapaa.logger.core
+
+/**
+ * Marks API that is internal to the KMP Logger library and reserved exclusively for
+ * the `logger-coroutines` module.
+ *
+ * Currently applied to [LogContextHolder.setContext][dev.shivathapaa.logger.core.LogContextHolder.setContext],
+ * which is the bridge between the coroutine context machinery in `logger-coroutines`
+ * and the platform-specific context storage in `logger`. Application code should use
+ * [LogContextHolder.withContext][dev.shivathapaa.logger.core.LogContextHolder.withContext],
+ * [LogContextHolder.withSuspendingContext][dev.shivathapaa.logger.core.LogContextHolder.withSuspendingContext],
+ * or [withLogContext][dev.shivathapaa.logger.coroutines.withLogContext] instead.
+ *
+ * These APIs may change incompatibly or be removed in future releases without notice.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This is an internal KMP Logger API reserved for the logger-coroutines module. " +
+            "Use LogContextHolder.withContext, withSuspendingContext, or withLogContext instead. " +
+            "This API may change incompatibly or be removed without notice."
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+annotation class InternalLoggerApi

--- a/logger/src/commonMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.kt
+++ b/logger/src/commonMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.kt
@@ -52,12 +52,22 @@ expect object LogContextHolder {
      * into the current context, then restores the previous context regardless
      * of whether [block] throws or suspends.
      *
-     * **JVM/Android note:** This implementation uses a `ThreadLocal` to hold
+     * **Thread-safety warning (JVM/Android):** This implementation uses a `ThreadLocal` to hold
      * the context. If the coroutine suspends and resumes on a different thread
-     * (e.g. with `Dispatchers.IO`), the context will not propagate to the
-     * resumed thread. Use with single-threaded dispatchers (e.g.
-     * `Dispatchers.Main`) or ensure the coroutine does not migrate threads
-     * across suspension points.
+     * (e.g. with `Dispatchers.IO` or `Dispatchers.Default`), the restored context
+     * will not be visible on the new thread. Concurrent coroutines that yield and
+     * interleave on the same dispatcher can also observe each other's context.
+     *
+     * For correct context propagation across suspension points and thread hops,
+     * prefer [withLogContext][dev.shivathapaa.logger.coroutines.withLogContext]
+     * from the `logger-coroutines` module, which uses
+     * [LogContextElement][dev.shivathapaa.logger.coroutines.LogContextElement]
+     * (a `ThreadContextElement` on JVM/Android) to install and restore the context
+     * automatically on every thread the coroutine resumes on.
+     *
+     * This function is safe to use when:
+     * - The coroutine always resumes on the same thread (e.g. `Dispatchers.Main`), or
+     * - No other coroutines run concurrently on the same dispatcher.
      *
      * @param ctx The context to merge into the current context for the
      *   duration of [block].
@@ -65,4 +75,26 @@ expect object LogContextHolder {
      * @return The value returned by [block].
      */
     suspend fun <T> withSuspendingContext(ctx: LogContext, block: suspend () -> T): T
+
+    /**
+     * Directly sets the active [LogContext] for the current thread or execution scope,
+     * replacing any previously installed context without merging.
+     *
+     * Passing an empty [LogContext] clears the active context entirely (equivalent
+     * to removing it from the current scope).
+     *
+     * **This is an internal API** used exclusively by the `logger-coroutines` module:
+     * - On **JVM/Android**: called by
+     *   [LogContextElement][dev.shivathapaa.logger.coroutines.LogContextElement]'s
+     *   `ThreadContextElement.updateThreadContext` and `restoreThreadContext` hooks,
+     *   which the coroutine dispatcher invokes automatically on each thread switch.
+     * - On **all other platforms**: called directly by
+     *   [withLogContext][dev.shivathapaa.logger.coroutines.withLogContext] to install
+     *   and restore the context around the coroutine block.
+     *
+     * Do not call this from application code. Use [withContext] or
+     * [withLogContext][dev.shivathapaa.logger.coroutines.withLogContext] instead.
+     */
+    @InternalLoggerApi
+    fun setContext(ctx: LogContext)
 }

--- a/logger/src/commonMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.kt
+++ b/logger/src/commonMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.kt
@@ -46,4 +46,23 @@ expect object LogContextHolder {
      * @return The value returned by [block].
      */
     fun <T> withContext(ctx: LogContext, block: () -> T): T
+
+    /**
+     * Suspending variant of [withContext] for use in coroutines. Executes [block] with [ctx] merged
+     * into the current context, then restores the previous context regardless
+     * of whether [block] throws or suspends.
+     *
+     * **JVM/Android note:** This implementation uses a `ThreadLocal` to hold
+     * the context. If the coroutine suspends and resumes on a different thread
+     * (e.g. with `Dispatchers.IO`), the context will not propagate to the
+     * resumed thread. Use with single-threaded dispatchers (e.g.
+     * `Dispatchers.Main`) or ensure the coroutine does not migrate threads
+     * across suspension points.
+     *
+     * @param ctx The context to merge into the current context for the
+     *   duration of [block].
+     * @param block The suspending block of code to execute within the merged context.
+     * @return The value returned by [block].
+     */
+    suspend fun <T> withSuspendingContext(ctx: LogContext, block: suspend () -> T): T
 }

--- a/logger/src/commonTest/kotlin/dev/shivathapaa/logger/LogContextHolderTest.kt
+++ b/logger/src/commonTest/kotlin/dev/shivathapaa/logger/LogContextHolderTest.kt
@@ -1,15 +1,24 @@
 package dev.shivathapaa.logger
 
+import dev.shivathapaa.logger.core.InternalLoggerApi
 import dev.shivathapaa.logger.core.LogContext
 import dev.shivathapaa.logger.core.LogContextHolder
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class LogContextHolderTest {
+
+    @OptIn(InternalLoggerApi::class)
+    @AfterTest
+    fun cleanup() {
+        LogContextHolder.setContext(LogContext())
+    }
 
     @Test
     fun currentReturnsEmptyContextByDefault() {
@@ -154,5 +163,87 @@ class LogContextHolderTest {
             assertEquals("t-1", current.values["traceId"])
             assertEquals(null, current.values["spanId"])
         }
+    }
+
+    // setContext 
+
+    @OptIn(InternalLoggerApi::class)
+    @Test
+    fun setContextWithNonEmptyContextSetsCurrentContext() {
+        LogContextHolder.setContext(LogContext(mapOf("key" to "value")))
+        assertEquals("value", LogContextHolder.current().values["key"])
+    }
+
+    @OptIn(InternalLoggerApi::class)
+    @Test
+    fun setContextWithEmptyContextClearsCurrentContext() {
+        LogContextHolder.setContext(LogContext(mapOf("key" to "value")))
+        LogContextHolder.setContext(LogContext())
+        assertTrue(LogContextHolder.current().values.isEmpty())
+    }
+
+    @OptIn(InternalLoggerApi::class)
+    @Test
+    fun setContextOverridesPreviousContextWithoutMerging() {
+        LogContextHolder.setContext(LogContext(mapOf("a" to "1", "b" to "2")))
+        LogContextHolder.setContext(LogContext(mapOf("a" to "override")))
+
+        val current = LogContextHolder.current()
+        assertEquals("override", current.values["a"])
+        assertNull(current.values["b"]) // "b" not merged  completely replaced
+    }
+
+    @OptIn(InternalLoggerApi::class)
+    @Test
+    fun setContextRetainsExactValues() {
+        val ctx = LogContext(mapOf("x" to "1", "y" to "2", "z" to "3"))
+        LogContextHolder.setContext(ctx)
+        assertEquals(ctx.values, LogContextHolder.current().values)
+    }
+
+    @OptIn(InternalLoggerApi::class)
+    @Test
+    fun setContextSequentialCallsLastOneWins() {
+        LogContextHolder.setContext(LogContext(mapOf("k" to "first")))
+        LogContextHolder.setContext(LogContext(mapOf("k" to "second")))
+        LogContextHolder.setContext(LogContext(mapOf("k" to "third")))
+        assertEquals("third", LogContextHolder.current().values["k"])
+    }
+
+    @OptIn(InternalLoggerApi::class)
+    @Test
+    fun setContextMultipleEmptyCallsReturnEmptyContext() {
+        LogContextHolder.setContext(LogContext())
+        LogContextHolder.setContext(LogContext())
+        assertTrue(LogContextHolder.current().values.isEmpty())
+    }
+
+    @OptIn(InternalLoggerApi::class)
+    @Test
+    fun setContextInsideWithContextIsOverriddenByWithContextRestore() {
+        val outer = LogContext(mapOf("a" to "1"))
+
+        LogContextHolder.withContext(outer) {
+            // setContext inside withContext changes the thread-local mid-block
+            LogContextHolder.setContext(LogContext(mapOf("b" to "hijacked")))
+            assertEquals("hijacked", LogContextHolder.current().values["b"])
+        }
+
+        // withContext finally restores to the snapshot captured before the block,
+        // so the setContext side-effect does not escape the withContext scope
+        assertTrue(LogContextHolder.current().values.isEmpty())
+    }
+
+    @OptIn(InternalLoggerApi::class)
+    @Test
+    fun setContextWithMultipleKeysThenClearLeavesNothingBehind() {
+        LogContextHolder.setContext(LogContext(mapOf("p" to "1", "q" to "2", "r" to "3")))
+        LogContextHolder.setContext(LogContext())
+
+        val current = LogContextHolder.current()
+        assertNull(current.values["p"])
+        assertNull(current.values["q"])
+        assertNull(current.values["r"])
+        assertTrue(current.values.isEmpty())
     }
 }

--- a/logger/src/commonTest/kotlin/dev/shivathapaa/logger/LogContextHolderTest.kt
+++ b/logger/src/commonTest/kotlin/dev/shivathapaa/logger/LogContextHolderTest.kt
@@ -2,10 +2,12 @@ package dev.shivathapaa.logger
 
 import dev.shivathapaa.logger.core.LogContext
 import dev.shivathapaa.logger.core.LogContextHolder
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class LogContextHolderTest {
 
@@ -79,6 +81,66 @@ class LogContextHolderTest {
         val result = LogContextHolder.withContext(ctx) { 42 }
 
         assertEquals(42, result)
+    }
+
+    @Test
+    fun suspendWithContextInstallsContext() = runTest {
+        val ctx = LogContext(mapOf("requestId" to "req-suspend"))
+
+        LogContextHolder.withSuspendingContext(ctx) {
+            yield()
+            assertEquals("req-suspend", LogContextHolder.current().values["requestId"])
+        }
+    }
+
+    @Test
+    fun suspendWithContextRestoresPreviousContextAfterBlock() = runTest {
+        val ctx = LogContext(mapOf("requestId" to "req-suspend"))
+
+        LogContextHolder.withSuspendingContext(ctx) { yield() }
+
+        assertTrue(LogContextHolder.current().values.isEmpty())
+    }
+
+    @Test
+    fun suspendWithContextRestoresContextOnException() = runTest {
+        val ctx = LogContext(mapOf("requestId" to "req-suspend"))
+
+        assertFailsWith<RuntimeException> {
+            LogContextHolder.withSuspendingContext(ctx) {
+                yield()
+                throw RuntimeException("test error")
+            }
+        }
+
+        assertTrue(LogContextHolder.current().values.isEmpty())
+    }
+
+    @Test
+    fun suspendWithContextPropagatesReturnValue() = runTest {
+        val ctx = LogContext(mapOf("k" to "v"))
+
+        val result = LogContextHolder.withSuspendingContext(ctx) {
+            yield()
+            42
+        }
+
+        assertEquals(42, result)
+    }
+
+    @Test
+    fun suspendWithContextNestedMerge() = runTest {
+        val outer = LogContext(mapOf("traceId" to "t-1"))
+        val inner = LogContext(mapOf("spanId" to "s-1"))
+
+        LogContextHolder.withSuspendingContext(outer) {
+            LogContextHolder.withSuspendingContext(inner) {
+                yield()
+                val current = LogContextHolder.current()
+                assertEquals("t-1", current.values["traceId"])
+                assertEquals("s-1", current.values["spanId"])
+            }
+        }
     }
 
     @Test

--- a/logger/src/jsMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.js.kt
+++ b/logger/src/jsMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.js.kt
@@ -24,4 +24,9 @@ actual object LogContextHolder {
             current = previous
         }
     }
+
+    @InternalLoggerApi
+    actual fun setContext(ctx: LogContext) {
+        current = ctx
+    }
 }

--- a/logger/src/jsMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.js.kt
+++ b/logger/src/jsMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.js.kt
@@ -14,4 +14,14 @@ actual object LogContextHolder {
             current = previous
         }
     }
+
+    actual suspend fun <T> withSuspendingContext(ctx: LogContext, block: suspend () -> T): T {
+        val previous = current
+        current = previous.merge(ctx)
+        try {
+            return block()
+        } finally {
+            current = previous
+        }
+    }
 }

--- a/logger/src/jvmMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.jvm.kt
+++ b/logger/src/jvmMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.jvm.kt
@@ -24,4 +24,9 @@ actual object LogContextHolder {
             holder.set(previous)
         }
     }
+
+    @InternalLoggerApi
+    actual fun setContext(ctx: LogContext) {
+        if (ctx.values.isEmpty()) holder.remove() else holder.set(ctx)
+    }
 }

--- a/logger/src/jvmMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.jvm.kt
+++ b/logger/src/jvmMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.jvm.kt
@@ -14,4 +14,14 @@ actual object LogContextHolder {
             holder.set(previous)
         }
     }
+
+    actual suspend fun <T> withSuspendingContext(ctx: LogContext, block: suspend () -> T): T {
+        val previous = current()
+        holder.set(previous.merge(ctx))
+        try {
+            return block()
+        } finally {
+            holder.set(previous)
+        }
+    }
 }

--- a/logger/src/linuxMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.linux.kt
+++ b/logger/src/linuxMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.linux.kt
@@ -24,4 +24,9 @@ actual object LogContextHolder {
             current = previous
         }
     }
+
+    @InternalLoggerApi
+    actual fun setContext(ctx: LogContext) {
+        current = ctx
+    }
 }

--- a/logger/src/linuxMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.linux.kt
+++ b/logger/src/linuxMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.linux.kt
@@ -14,4 +14,14 @@ actual object LogContextHolder {
             current = previous
         }
     }
+
+    actual suspend fun <T> withSuspendingContext(ctx: LogContext, block: suspend () -> T): T {
+        val previous = current
+        current = previous.merge(ctx)
+        try {
+            return block()
+        } finally {
+            current = previous
+        }
+    }
 }

--- a/logger/src/mingwMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.mingw.kt
+++ b/logger/src/mingwMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.mingw.kt
@@ -24,4 +24,9 @@ actual object LogContextHolder {
             current = previous
         }
     }
+
+    @InternalLoggerApi
+    actual fun setContext(ctx: LogContext) {
+        current = ctx
+    }
 }

--- a/logger/src/mingwMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.mingw.kt
+++ b/logger/src/mingwMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.mingw.kt
@@ -14,4 +14,14 @@ actual object LogContextHolder {
             current = previous
         }
     }
+
+    actual suspend fun <T> withSuspendingContext(ctx: LogContext, block: suspend () -> T): T {
+        val previous = current
+        current = previous.merge(ctx)
+        try {
+            return block()
+        } finally {
+            current = previous
+        }
+    }
 }

--- a/logger/src/wasmJsMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.wasmJs.kt
+++ b/logger/src/wasmJsMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.wasmJs.kt
@@ -24,4 +24,9 @@ actual object LogContextHolder {
             current = previous
         }
     }
+
+    @InternalLoggerApi
+    actual fun setContext(ctx: LogContext) {
+        current = ctx
+    }
 }

--- a/logger/src/wasmJsMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.wasmJs.kt
+++ b/logger/src/wasmJsMain/kotlin/dev/shivathapaa/logger/core/LogContextHolder.wasmJs.kt
@@ -14,4 +14,14 @@ actual object LogContextHolder {
             current = previous
         }
     }
+
+    actual suspend fun <T> withSuspendingContext(ctx: LogContext, block: suspend () -> T): T {
+        val previous = current
+        current = previous.merge(ctx)
+        try {
+            return block()
+        } finally {
+            current = previous
+        }
+    }
 }

--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
             implementation(libs.foundation)
             implementation(libs.material3)
             implementation(project(":logger"))
+            implementation(project(":logger-coroutines"))
 //            implementation(libs.logger)
         }
         jvmMain.dependencies {

--- a/sample/composeApp/src/commonMain/kotlin/sample/app/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/sample/app/App.kt
@@ -16,9 +16,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
+enum class SampleScreen { SIMPLE, STRUCTURED, COROUTINE }
+
 @Composable
 fun App() {
-    val isSimpleApiLoggerSampleVisible = rememberSaveable { mutableStateOf(true) }
+    val screen = rememberSaveable { mutableStateOf(SampleScreen.SIMPLE) }
 
     Scaffold { paddingValues ->
         Column(
@@ -30,24 +32,27 @@ fun App() {
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
                     .animateContentSize(),
                 onClick = {
-                    isSimpleApiLoggerSampleVisible.value = !isSimpleApiLoggerSampleVisible.value
+                    screen.value = when (screen.value) {
+                        SampleScreen.SIMPLE -> SampleScreen.STRUCTURED
+                        SampleScreen.STRUCTURED -> SampleScreen.COROUTINE
+                        SampleScreen.COROUTINE -> SampleScreen.SIMPLE
+                    }
                 },
                 shape = MaterialTheme.shapes.small
             ) {
-                val buttonText = if (isSimpleApiLoggerSampleVisible.value) {
-                    "Checkout structured api samples"
-                } else {
-                    "Checkout simple api samples"
+                val buttonText = when (screen.value) {
+                    SampleScreen.SIMPLE -> "Switch to Structured API"
+                    SampleScreen.STRUCTURED -> "Switch to Coroutine API"
+                    SampleScreen.COROUTINE -> "Switch to Simple API"
                 }
                 Text(buttonText, modifier = Modifier.animateContentSize())
             }
 
-            AnimatedContent(
-                targetState = isSimpleApiLoggerSampleVisible.value
-            ) { isSimpleVisible ->
-                when (isSimpleVisible) {
-                    true -> SimpleLogSample()
-                    false -> StructuredLogApiSample()
+            AnimatedContent(targetState = screen.value) { current ->
+                when (current) {
+                    SampleScreen.SIMPLE -> SimpleLogSample()
+                    SampleScreen.STRUCTURED -> StructuredLogApiSample()
+                    SampleScreen.COROUTINE -> CoroutineLogApiSample()
                 }
             }
         }

--- a/sample/composeApp/src/commonMain/kotlin/sample/app/CoroutineLogApiSample.kt
+++ b/sample/composeApp/src/commonMain/kotlin/sample/app/CoroutineLogApiSample.kt
@@ -1,0 +1,392 @@
+package sample.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import dev.shivathapaa.logger.api.LogLevel
+import dev.shivathapaa.logger.api.LoggerFactory
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import dev.shivathapaa.logger.core.LoggerConfig
+import dev.shivathapaa.logger.coroutines.LogContextElement
+import dev.shivathapaa.logger.coroutines.withLogContext
+import dev.shivathapaa.logger.sink.DefaultLogSink
+import dev.shivathapaa.logger.sink.TestSink
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Demonstrates the logger-coroutines module: safe LogContext propagation
+ * across suspension points and thread hops using [withLogContext].
+ */
+@Composable
+fun CoroutineLogApiSample(modifier: Modifier = Modifier) {
+    LaunchedEffect(Unit) {
+        initCoroutineLogger()
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize().verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text("Coroutine Log API Demo", style = MaterialTheme.typography.headlineMedium)
+        Text(
+            "Check console for log outputs",
+            color = Color.Gray,
+            style = MaterialTheme.typography.bodySmall
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Text("withLogContext", style = MaterialTheme.typography.titleMedium)
+        DemoButton("1. Basic withLogContext", ::basicWithLogContext)
+        DemoButton("2. Context Survives Suspension", ::contextSurvivesSuspension)
+        DemoButton("3. Context Survives Thread Hop", ::contextSurvivesThreadHop)
+        DemoButton("4. Nested withLogContext", ::nestedWithLogContext)
+
+        Spacer(Modifier.height(8.dp))
+
+        Text("Comparison & Scope", style = MaterialTheme.typography.titleMedium)
+        DemoButton("5. withSuspendingContext (core)", ::withSuspendingContextDemo)
+        DemoButton("6. LogContextElement on Scope", ::logContextElementOnScope)
+
+        Spacer(Modifier.height(8.dp))
+
+        Text("Concurrency & Real-World", style = MaterialTheme.typography.titleMedium)
+        DemoButton("7. Concurrent Coroutine Isolation", ::concurrentCoroutineIsolation)
+        DemoButton("8. Request Pipeline Simulation", ::requestPipelineSimulation)
+        DemoButton("9. TestSink Verification", ::coroutineTestSinkVerification)
+
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+fun initCoroutineLogger() {
+    printHeader("INITIALIZING LOGGER (Coroutine Demo)")
+
+    val config = LoggerConfig.Builder()
+        .minLevel(LogLevel.DEBUG)
+        .addSink(DefaultLogSink())
+        .build()
+
+    LoggerFactory.install(config)
+    println("** Logger initialized with DEBUG level and DefaultLogSink")
+}
+
+/**
+ * Demonstrates basic withLogContext: context is attached for the block duration
+ * and automatically removed when the block completes.
+ */
+fun basicWithLogContext() {
+    printHeader("1. BASIC withLogContext")
+
+    CoroutineScope(Dispatchers.Default).launch {
+        val logger = LoggerFactory.get("CoroutineBasic")
+        val ctx = LogContext(mapOf("requestId" to "req-001", "userId" to 42))
+
+        println("* Before withLogContext - no context:")
+        logger.info { "No context here" }
+
+        withLogContext(ctx) {
+            println("* Inside withLogContext - context attached:")
+            logger.info { "Has requestId and userId in context" }
+            logger.debug { "Context is automatically included in every log" }
+        }
+
+        println("* After withLogContext - context removed:")
+        logger.info { "Context is gone again" }
+
+        println("** withLogContext scopes context to the block")
+    }
+}
+
+/**
+ * Demonstrates that context survives suspension points (delay, yield, etc.).
+ */
+fun contextSurvivesSuspension() {
+    printHeader("2. CONTEXT SURVIVES SUSPENSION")
+
+    CoroutineScope(Dispatchers.Default).launch {
+        val logger = LoggerFactory.get("SuspensionDemo")
+        val ctx = LogContext(mapOf("operationId" to "op-suspend-test"))
+
+        withLogContext(ctx) {
+            logger.info { "Before suspension - operationId in context" }
+
+            delay(50)  // suspension point
+            logger.info { "After delay(50) - context still present" }
+
+            delay(100) // another suspension point
+            logger.info { "After delay(100) - context still present" }
+        }
+
+        println("** Context survives suspension on all platforms")
+    }
+}
+
+/**
+ * Demonstrates that context survives thread hops via withContext.
+ * On JVM/Android this exercises the ThreadContextElement mechanism.
+ * On single-threaded platforms (JS, iOS, etc.) there is no thread switch
+ * but the test still passes correctly.
+ */
+fun contextSurvivesThreadHop() {
+    printHeader("3. CONTEXT SURVIVES THREAD HOP")
+
+    CoroutineScope(Dispatchers.Default).launch {
+        val logger = LoggerFactory.get("ThreadHopDemo")
+        val ctx = LogContext(mapOf("traceId" to "trace-thread-hop"))
+
+        withLogContext(ctx) {
+            logger.info { "Original coroutine context - traceId present" }
+
+            withContext(Dispatchers.Default) {
+                // On JVM/Android: different thread, ThreadContextElement restores context
+                // On JS/iOS/etc.: same thread, context is still set
+                logger.info { "After withContext(Default) - traceId still present" }
+                delay(30)
+                logger.debug { "After delay inside thread hop - traceId still present" }
+            }
+
+            logger.info { "Back to original context - traceId still present" }
+        }
+
+        println("** On JVM/Android: ThreadContextElement auto-installs on every thread resume")
+        println("** On JS/iOS/native: single-threaded, context set directly on LogContextHolder")
+    }
+}
+
+/**
+ * Demonstrates that nested withLogContext calls merge their contexts.
+ * Inner keys override outer keys on collision.
+ */
+fun nestedWithLogContext() {
+    printHeader("4. NESTED withLogContext")
+
+    CoroutineScope(Dispatchers.Default).launch {
+        val logger = LoggerFactory.get("NestedCoroutineDemo")
+
+        val outerCtx = LogContext(mapOf("traceId" to "trace-999", "service" to "api"))
+        val innerCtx = LogContext(mapOf("spanId" to "span-456", "service" to "db"))
+
+        withLogContext(outerCtx) {
+            logger.info { "Outer: traceId=trace-999, service=api" }
+
+            withLogContext(innerCtx) {
+                // spanId added, service overrides to "db"
+                logger.info { "Inner: traceId=trace-999, spanId=span-456, service=db" }
+
+                delay(20)
+                logger.debug { "After delay in inner - still merged context" }
+            }
+
+            logger.info { "Back to outer: traceId=trace-999, service=api" }
+        }
+
+        logger.info { "Outside all blocks - no context" }
+        println("** Nested contexts merge; inner values override outer on key collision")
+    }
+}
+
+/**
+ * Demonstrates withSuspendingContext from the core module.
+ * Safe on single-threaded dispatchers; limited on JVM/Android with thread hops.
+ */
+fun withSuspendingContextDemo() {
+    printHeader("5. withSuspendingContext (CORE, LIMITED)")
+
+    CoroutineScope(Dispatchers.Default).launch {
+        val logger = LoggerFactory.get("SuspendingContextDemo")
+        val ctx = LogContext(mapOf("source" to "withSuspendingContext"))
+
+        // Safe: stays on the same dispatcher thread after a simple delay
+        LogContextHolder.withSuspendingContext(ctx) {
+            logger.info { "Inside withSuspendingContext - source present" }
+            delay(30)
+            // NOTE: On JVM/Android with multi-threaded dispatchers, context may be
+            // missing here if the coroutine resumed on a different thread.
+            // Use withLogContext from logger-coroutines for guaranteed propagation.
+            logger.info { "After delay - context present (safe if no thread switch)" }
+        }
+
+        println("** withSuspendingContext: use withLogContext for guaranteed propagation on JVM/Android")
+    }
+}
+
+/**
+ * Demonstrates attaching a LogContextElement to an entire CoroutineScope,
+ * so every coroutine launched in that scope inherits the context.
+ */
+fun logContextElementOnScope() {
+    printHeader("6. LogContextElement ON SCOPE")
+
+    val serviceCtx = LogContext(mapOf("service" to "payment-api", "version" to "v2"))
+    val scope = CoroutineScope(Dispatchers.Default + LogContextElement(serviceCtx))
+
+    scope.launch {
+        val logger = LoggerFactory.get("ScopeCtxDemo")
+
+        logger.info { "Coroutine 1: inherits service=payment-api, version=v2 from scope" }
+
+        withLogContext(LogContext(mapOf("orderId" to "ORD-123"))) {
+            // Merges scope context with local context
+            logger.info { "With extra orderId: service=payment-api, version=v2, orderId=ORD-123" }
+        }
+    }
+
+    scope.launch {
+        delay(10)
+        val logger = LoggerFactory.get("ScopeCtxDemo2")
+        logger.info { "Coroutine 2: also inherits service=payment-api, version=v2 from scope" }
+    }
+
+    println("** LogContextElement on scope: all child coroutines inherit the context")
+}
+
+/**
+ * Demonstrates that concurrent coroutines with different contexts do not
+ * interfere with each other.
+ */
+fun concurrentCoroutineIsolation() {
+    printHeader("7. CONCURRENT COROUTINE ISOLATION")
+
+    val scope = CoroutineScope(Dispatchers.Default)
+
+    scope.launch {
+        val logger = LoggerFactory.get("ConcurrencyDemo")
+
+        val job1 = launch {
+            withLogContext(LogContext(mapOf("coroutine" to "A", "userId" to 1))) {
+                repeat(3) { i ->
+                    delay(20)
+                    logger.info { "Coroutine A step $i - userId=1" }
+                }
+            }
+        }
+
+        val job2 = launch {
+            withLogContext(LogContext(mapOf("coroutine" to "B", "userId" to 2))) {
+                repeat(3) { i ->
+                    delay(15)
+                    logger.info { "Coroutine B step $i - userId=2" }
+                }
+            }
+        }
+
+        job1.join()
+        job2.join()
+
+        println("** Concurrent coroutines maintain isolated contexts")
+        println("** Each userId log entry matches its coroutine (no cross-contamination)")
+    }
+}
+
+/**
+ * Simulates a real-world request pipeline where context flows through
+ * multiple async operations: auth check, data fetch, response building.
+ */
+fun requestPipelineSimulation() {
+    printHeader("8. REQUEST PIPELINE SIMULATION")
+
+    CoroutineScope(Dispatchers.Default).launch {
+        val requestId = "req-${(1000..9999).random()}"
+        val userId = (100..999).random()
+
+        val baseCtx = LogContext(mapOf("requestId" to requestId, "userId" to userId))
+
+        withLogContext(baseCtx) {
+            val logger = LoggerFactory.get("RequestPipeline")
+            logger.info { "Incoming request" }
+
+            // Auth phase
+            withLogContext(LogContext(mapOf("phase" to "auth"))) {
+                logger.debug { "Checking token" }
+                delay(20)
+                logger.info { "Token valid" }
+            }
+
+            // Data fetch phase
+            withLogContext(LogContext(mapOf("phase" to "fetch"))) {
+                logger.debug { "Querying database" }
+                withContext(Dispatchers.Default) {
+                    delay(40)
+                    logger.debug(
+                        attrs = { attr("rows", 5) }
+                    ) { "Query complete" }
+                }
+            }
+
+            // Response phase
+            withLogContext(LogContext(mapOf("phase" to "response"))) {
+                logger.debug { "Building response" }
+                delay(10)
+                logger.info(
+                    attrs = { attr("statusCode", 200); attr("durationMs", 70) }
+                ) { "Request complete" }
+            }
+        }
+
+        println("** Request ID and user ID flowed through auth, fetch, and response phases")
+    }
+}
+
+/**
+ * Demonstrates using TestSink to assert that context values are present
+ * in logs emitted from within withLogContext.
+ */
+fun coroutineTestSinkVerification() {
+    printHeader("9. TEST SINK VERIFICATION")
+
+    CoroutineScope(Dispatchers.Default).launch {
+        val testSink = TestSink()
+        val config = LoggerConfig.Builder()
+            .minLevel(LogLevel.DEBUG)
+            .addSink(testSink)
+            .build()
+        LoggerFactory.install(config)
+
+        val logger = LoggerFactory.get("CoroutineTestVerify")
+        val ctx = LogContext(mapOf("testRun" to "coroutine-ctx-test", "env" to "sample"))
+
+        withLogContext(ctx) {
+            delay(10)
+            logger.info { "Log inside coroutine context" }
+            delay(10)
+            logger.debug(attrs = { attr("step", 1) }) { "Step completed" }
+        }
+
+        // Verify captured events
+        println("* Captured ${testSink.events.size} events:")
+        testSink.events.forEachIndexed { idx, event ->
+            val ctxValues = event.context.values
+            println("*  [$idx] ${event.level} - ${event.message}")
+            println("*      testRun: ${ctxValues["testRun"]}")
+            println("*      env: ${ctxValues["env"]}")
+            println("*      context intact: ${ctxValues["testRun"] == "coroutine-ctx-test"}")
+        }
+
+        val allHaveContext = testSink.events.all {
+            it.context.values["testRun"] == "coroutine-ctx-test"
+        }
+        println("** All ${testSink.events.size} events have correct context: $allHaveContext")
+
+        // Restore logger
+        initCoroutineLogger()
+    }
+}

--- a/sample/terminalApp/build.gradle.kts
+++ b/sample/terminalApp/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(project(":logger"))
+            implementation(project(":logger-coroutines"))
+            implementation(libs.kotlinx.coroutines.core)
         }
     }
 }

--- a/sample/terminalApp/src/commonMain/kotlin/main.kt
+++ b/sample/terminalApp/src/commonMain/kotlin/main.kt
@@ -1,9 +1,305 @@
 import dev.shivathapaa.logger.api.Log
+import dev.shivathapaa.logger.api.LogLevel
+import dev.shivathapaa.logger.api.LoggerFactory
+import dev.shivathapaa.logger.core.LogContext
+import dev.shivathapaa.logger.core.LogContextHolder
+import dev.shivathapaa.logger.core.LoggerConfig
+import dev.shivathapaa.logger.coroutines.LogContextElement
+import dev.shivathapaa.logger.coroutines.withLogContext
+import dev.shivathapaa.logger.sink.DefaultLogSink
+import dev.shivathapaa.logger.sink.TestSink
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
-fun main() {
-    Log.d("Default tag message")
-    Log.d("Network module message", tag = "Network")
-    Log.i("Auth module message", tag = "Auth")
-    Log.w("Database warning", tag = "Database")
-    Log.e("Cache error", tag = "Cache")
+fun main() = runBlocking {
+    setupLogger()
+
+    simpleApiSamples()
+    structuredApiSamples()
+    coroutineSamples()
+}
+
+// Setup
+fun setupLogger() {
+    printHeader("LOGGER SETUP")
+
+    val config = LoggerConfig.Builder()
+        .minLevel(LogLevel.DEBUG)
+        .addSink(DefaultLogSink())
+        .build()
+
+    LoggerFactory.install(config)
+    println("* Logger ready: minLevel=DEBUG, sink=DefaultLogSink")
+}
+
+// Simple API
+fun simpleApiSamples() {
+    printHeader("SIMPLE LOG API")
+
+    Log.setDefaultTag("TerminalApp")
+    Log.v("VERBOSE: trace detail")
+    Log.d("DEBUG: development info")
+    Log.i("INFO: app started")
+    Log.w("WARN: approaching limit")
+    Log.e("ERROR: something went wrong")
+
+    Log.i("Custom tag", tag = "Network")
+    Log.d("Another tag", tag = "Cache")
+
+    val log = Log.withTag("Auth")
+    log.i("User logged in")
+    log.d("Token refreshed")
+
+    println("* Simple Log API - done")
+}
+
+// Structured API
+fun structuredApiSamples() {
+    printHeader("STRUCTURED LOG API")
+
+    val logger = LoggerFactory.get("StructuredDemo")
+
+    logger.info(
+        attrs = {
+            attr("method", "POST")
+            attr("path", "/api/orders")
+            attr("statusCode", 201)
+            attr("durationMs", 84)
+        }
+    ) { "HTTP request" }
+
+    logger.debug(
+        attrs = {
+            attr("query", "SELECT * FROM users WHERE id = ?")
+            attr("params", listOf(123))
+            attr("executionTime", 12)
+        }
+    ) { "DB query" }
+
+    val ctx = LogContext(mapOf("requestId" to "req-term-001", "userId" to 77))
+    LogContextHolder.withContext(ctx) {
+        logger.info { "Inside sync context: requestId and userId attached" }
+        logger.debug { "All logs in this block carry the context" }
+    }
+    logger.info { "After withContext: context removed" }
+
+    println("* Structured Log API - done")
+}
+
+// Coroutine API
+suspend fun coroutineSamples() {
+    basicWithLogContextSample()
+    contextSurvivesSuspensionSample()
+    nestedWithLogContextSample()
+    withSuspendingContextSample()
+    logContextElementOnScopeSample()
+    concurrentIsolationSample()
+    requestPipelineSample()
+    testSinkSample()
+}
+
+suspend fun basicWithLogContextSample() {
+    printHeader("COROUTINE 1: BASIC withLogContext")
+
+    val logger = LoggerFactory.get("TermCoroutineBasic")
+    val ctx = LogContext(mapOf("requestId" to "req-coroutine-001", "env" to "terminal"))
+
+    logger.info { "Before withLogContext - no context" }
+
+    withLogContext(ctx) {
+        logger.info { "Inside withLogContext - requestId and env present" }
+        delay(10)
+        logger.debug { "After delay - context still present" }
+    }
+
+    logger.info { "After withLogContext - context removed" }
+    println("* Basic withLogContext - done")
+}
+
+suspend fun contextSurvivesSuspensionSample() {
+    printHeader("COROUTINE 2: CONTEXT SURVIVES SUSPENSION")
+
+    val logger = LoggerFactory.get("TermSuspensionDemo")
+    val ctx = LogContext(mapOf("operationId" to "op-suspend"))
+
+    withLogContext(ctx) {
+        logger.info { "Before delay - context present" }
+        delay(30)
+        logger.info { "After delay(30) - context still present" }
+        delay(50)
+        logger.info { "After delay(50) - context still present" }
+    }
+
+    println("* Context survives suspension - done")
+}
+
+suspend fun nestedWithLogContextSample() {
+    printHeader("COROUTINE 3: NESTED withLogContext")
+
+    val logger = LoggerFactory.get("TermNestedDemo")
+
+    val outerCtx = LogContext(mapOf("traceId" to "trace-term", "service" to "terminal"))
+    val innerCtx = LogContext(mapOf("spanId" to "span-db", "service" to "database"))
+
+    withLogContext(outerCtx) {
+        logger.info { "Outer: traceId=trace-term, service=terminal" }
+
+        withLogContext(innerCtx) {
+            // service overrides to "database", spanId added
+            logger.info { "Inner: traceId=trace-term, spanId=span-db, service=database" }
+            delay(10)
+            logger.debug { "After delay in inner - merged context still present" }
+        }
+
+        logger.info { "Back to outer: traceId=trace-term, service=terminal" }
+    }
+
+    println("* Nested withLogContext - done")
+}
+
+suspend fun withSuspendingContextSample() {
+    printHeader("COROUTINE 4: withSuspendingContext (CORE)")
+
+    val logger = LoggerFactory.get("TermSuspendingCtx")
+    val ctx = LogContext(mapOf("source" to "withSuspendingContext"))
+
+    // Safe here: single-threaded native dispatcher, no thread migration
+    LogContextHolder.withSuspendingContext(ctx) {
+        logger.info { "Inside withSuspendingContext - source present" }
+        delay(10)
+        logger.info { "After delay - context present (safe on native, limited on JVM)" }
+    }
+
+    println("* withSuspendingContext - done")
+    println("* Note: use withLogContext for guaranteed propagation on JVM/Android")
+}
+
+suspend fun logContextElementOnScopeSample() {
+    printHeader("COROUTINE 5: LogContextElement ON SCOPE")
+
+    val logger = LoggerFactory.get("TermScopeCtx")
+    val scopeCtx = LogContext(mapOf("service" to "terminal-app", "version" to "1.4.0"))
+    val scopeElement = LogContextElement(scopeCtx)
+
+    // Attach context to coroutine context directly
+    withContext(scopeElement) {
+        logger.info { "Inherited from context element: service=terminal-app, version=1.4.0" }
+
+        withLogContext(LogContext(mapOf("operation" to "read"))) {
+            logger.info { "Merged: service=terminal-app, version=1.4.0, operation=read" }
+        }
+    }
+
+    println("* LogContextElement on scope - done")
+}
+
+suspend fun concurrentIsolationSample() {
+    printHeader("COROUTINE 6: CONCURRENT ISOLATION")
+
+    val logger = LoggerFactory.get("TermConcurrencyDemo")
+
+    // On native these run cooperatively but contexts are restored correctly
+    coroutineScope {
+        launch {
+            withLogContext(LogContext(mapOf("worker" to "A", "taskId" to 1))) {
+                repeat(3) { i ->
+                    delay(15)
+                    logger.info { "Worker A step $i - taskId=1" }
+                }
+            }
+        }
+    }
+
+    // Sequential on native (no true parallelism), but context is correct either way
+    withLogContext(LogContext(mapOf("worker" to "B", "taskId" to 2))) {
+        repeat(3) { i ->
+            delay(10)
+            logger.info { "Worker B step $i - taskId=2" }
+        }
+    }
+
+    println("* Concurrent isolation - done")
+    println("* On native: cooperative, no thread migration. On JVM: true parallel with isolation.")
+}
+
+suspend fun requestPipelineSample() {
+    printHeader("COROUTINE 7: REQUEST PIPELINE")
+
+    val requestId = "req-term-${(1000..9999).random()}"
+    val userId = (100..999).random()
+    val logger = LoggerFactory.get("TermRequestPipeline")
+
+    withLogContext(LogContext(mapOf("requestId" to requestId, "userId" to userId))) {
+        logger.info { "Incoming request" }
+
+        withLogContext(LogContext(mapOf("phase" to "auth"))) {
+            logger.debug { "Verifying token" }
+            delay(15)
+            logger.info { "Token valid" }
+        }
+
+        withLogContext(LogContext(mapOf("phase" to "fetch"))) {
+            logger.debug { "Querying data store" }
+            delay(30)
+            logger.debug(attrs = { attr("rows", 3) }) { "Query complete" }
+        }
+
+        withLogContext(LogContext(mapOf("phase" to "response"))) {
+            logger.debug { "Serializing response" }
+            delay(5)
+            logger.info(attrs = {
+                attr("statusCode", 200); attr(
+                "durationMs",
+                50
+            )
+            }) { "Request complete" }
+        }
+    }
+
+    println("* Request pipeline - done")
+}
+
+suspend fun testSinkSample() {
+    printHeader("COROUTINE 8: TestSink VERIFICATION")
+
+    val testSink = TestSink()
+    val config = LoggerConfig.Builder()
+        .minLevel(LogLevel.DEBUG)
+        .addSink(testSink)
+        .build()
+    LoggerFactory.install(config)
+
+    val logger = LoggerFactory.get("TermTestVerify")
+    val ctx = LogContext(mapOf("testRun" to "terminal-coroutine", "env" to "native"))
+
+    withLogContext(ctx) {
+        delay(5)
+        logger.info { "Log inside coroutine context" }
+        delay(5)
+        logger.debug(attrs = { attr("step", 1) }) { "Step completed" }
+    }
+
+    println("* Captured ${testSink.events.size} events:")
+    testSink.events.forEachIndexed { idx, event ->
+        val ctxValues = event.context.values
+        println("*  [$idx] ${event.level} - ${event.message}")
+        println("*      testRun: ${ctxValues["testRun"]}, env: ${ctxValues["env"]}")
+        println("*      context intact: ${ctxValues["testRun"] == "terminal-coroutine"}")
+    }
+
+    val allCorrect = testSink.events.all { it.context.values["testRun"] == "terminal-coroutine" }
+    println("** All events have correct context: $allCorrect")
+
+    // Restore logger
+    setupLogger()
+}
+
+// Utility
+fun printHeader(title: String) {
+    println("\n${"=".repeat(70)}")
+    println(title)
+    println("=".repeat(70))
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "KMP-Logger"
 
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google()
         mavenCentral()
@@ -16,6 +17,8 @@ dependencyResolutionManagement {
 }
 
 include(":logger")
+include(":logger-coroutines")
+
 include(":sample:androidApp")
 include(":sample:composeApp")
 include(":sample:terminalApp")


### PR DESCRIPTION
This PR introduces coroutine-safe structured logging for Kotlin Multiplatform and improves overall tooling and examples.

- Add `withSuspendingContext` to core logger with documentation for thread-local limitations
- Introduce optional `logger-coroutines` module with `withLogContext` and `LogContextElement` for safe context propagation across suspension points and thread hops
- Add internal `setContext` API for coroutine context restoration (used by logger-coroutines)
- Refactor build using convention plugins (`kmplogger.kotlin-multiplatform`, `kmplogger.maven-publish`)
- Move versioning to `gradle.properties`
- Update CI to support multi-module testing and publishing (`:logger`, `:logger-coroutines`)
- Add coroutine logging demos to Compose and terminal sample apps